### PR TITLE
Atualização do código da lista de pré-natal

### DIFF
--- a/Scripts/lista_nominal_indicadores/lista_nominal_gestantes_unificada
+++ b/Scripts/lista_nominal_indicadores/lista_nominal_gestantes_unificada
@@ -2,441 +2,422 @@
 CREATE MATERIALIZED VIEW impulso_previne_dados_nominais.lista_nominal_gestantes_unificada
 TABLESPACE pg_default
 AS WITH base_atendimentos_pre_natal AS (
-         WITH base AS (
-                 SELECT DISTINCT b_1.municipio_id_sus,
-                    b_1.id_registro,
-                    b_1.data_registro AS data_atendimento,
-                    b_1.chave_gestante,
-                    b_1.profissional_nome_atendimento,
-                        CASE
-                            WHEN b_1.data_dum <> '3000-12-31'::date THEN b_1.data_dum
-                            WHEN b_1.idade_gestacional_atendimento IS NOT NULL THEN (b_1.data_registro - '7 days'::interval * b_1.idade_gestacional_atendimento::double precision)::date
-                            ELSE NULL::date
-                        END AS data_dum_atendimento,
-                        CASE
-                            WHEN b_1.data_dum <> '3000-12-31'::date THEN (b_1.data_dum + '294 days'::interval)::date
-                            WHEN b_1.idade_gestacional_atendimento IS NOT NULL THEN (b_1.data_registro - '7 days'::interval * b_1.idade_gestacional_atendimento::double precision + '294 days'::interval)::date
-                            ELSE NULL::date
-                        END AS data_dpp_atendimento,
-                        CASE
-                            WHEN b_1.data_dum <> '3000-12-31'::date THEN (CURRENT_DATE - b_1.data_dum) / 7
-                            WHEN b_1.idade_gestacional_atendimento IS NOT NULL THEN (CURRENT_DATE - (b_1.data_registro - '7 days'::interval * b_1.idade_gestacional_atendimento::double precision)::date) / 7
-                            ELSE NULL::integer
-                        END AS gestante_idade_gestacional,
-                        CASE
-                            WHEN b_1.idade_gestacional_atendimento IS NOT NULL THEN b_1.idade_gestacional_atendimento
-                            WHEN b_1.data_dum <> '3000-12-31'::date THEN (b_1.data_registro - b_1.data_dum) / 7
-                            ELSE NULL::integer
-                        END AS gestante_idade_gestacional_atendimento
-                   FROM impulso_previne_dados_nominais.eventos_pre_natal b_1
-                  WHERE b_1.tipo_registro::text = 'consulta_pre_natal'::text
-                )
-         SELECT b.municipio_id_sus,
-            b.id_registro,
-            b.data_atendimento,
-            b.chave_gestante,
-            b.profissional_nome_atendimento,
-            b.data_dum_atendimento,
-            b.data_dpp_atendimento,
-            b.gestante_idade_gestacional,
-            b.gestante_idade_gestacional_atendimento,
-            (array_agg(b.data_atendimento) FILTER (WHERE b.data_dum_atendimento IS NOT NULL) OVER (PARTITION BY b.chave_gestante ORDER BY b.id_registro ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING))[1] AS primeira_data_consulta_pre_natal_com_dum,
+    WITH base AS (
+        SELECT 
+            DISTINCT
+                b.id_registro,
+                b.data_registro AS data_atendimento,
+                b.chave_gestante,
+                b.profissional_nome_atendimento,
+                -- Se a data de DUM é inválida ('3000-12-31'), procuramos o registro de idade_gestacional (casos de ficha CDS)
+                CASE
+                    WHEN COALESCE(b.data_dum,'3000-12-31'::date) <> '3000-12-31'::date
+                        THEN b.data_dum
+                    WHEN b.idade_gestacional_atendimento IS NOT NULL 
+                        THEN (b.data_registro - '7 days'::interval * b.idade_gestacional_atendimento::double precision)::date
+                    ELSE NULL::date
+                END AS data_dum_atendimento,
+                CASE
+                    WHEN COALESCE(b.data_dum,'3000-12-31'::date) <> '3000-12-31'::date
+                        THEN (b.data_dum + '294 days'::INTERVAL)::date
+                    WHEN b.idade_gestacional_atendimento IS NOT NULL 
+                        THEN (b.data_registro - '7 days'::interval * b.idade_gestacional_atendimento::double precision + '294 days'::INTERVAL)::date
+                    ELSE NULL::date
+                END AS data_dpp_atendimento,
+                CASE
+                    WHEN COALESCE(b.data_dum,'3000-12-31'::date) <> '3000-12-31'::date
+                        THEN (CURRENT_DATE - b.data_dum) / 7
+                    WHEN b.idade_gestacional_atendimento IS NOT NULL 
+                        THEN (CURRENT_DATE - (b.data_registro - '7 days'::interval * b.idade_gestacional_atendimento::double precision)::date) / 7
+                    ELSE NULL::integer
+                END AS gestante_idade_gestacional,
+                CASE 
+                    WHEN COALESCE(b.data_dum,'3000-12-31'::date) <> '3000-12-31'::date
+                        THEN (b.data_registro - b.data_dum) / 7
+                    WHEN b.idade_gestacional_atendimento IS NOT NULL
+                        THEN b.idade_gestacional_atendimento
+                    ELSE NULL::integer
+                END AS gestante_idade_gestacional_atendimento
+            FROM impulso_previne_dados_nominais.eventos_pre_natal b
+            WHERE b.tipo_registro = 'consulta_pre_natal'
+            )       
+        SELECT 
+            b.*,
+            -- Pelas regras do SISAB a data de DUM considerada na gestação é a primeira data com registro válido 
+            (array_agg(b.data_atendimento) FILTER (WHERE b.data_dum_atendimento IS NOT NULL) OVER (PARTITION BY b.chave_gestante ORDER BY b.id_registro ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING))[1] AS primeira_data_consulta_pre_natal_com_DUM,
             (array_agg(b.data_dum_atendimento) FILTER (WHERE b.data_dum_atendimento IS NOT NULL) OVER (PARTITION BY b.chave_gestante ORDER BY b.id_registro ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING))[1] AS primeira_data_dum_valida
-           FROM base b
-        ), validacao_dum AS (
-         SELECT apn.municipio_id_sus,
-            apn.chave_gestante,
-            count(DISTINCT apn.id_registro) AS consultas_pre_natal,
-            count(DISTINCT
-                CASE
-                    WHEN apn.data_dum_atendimento IS NOT NULL THEN apn.data_dum_atendimento
-                    ELSE NULL::date
-                END) AS cont_data_dum_validas,
-            count(DISTINCT
-                CASE
-                    WHEN apn.data_dum_atendimento IS NULL THEN apn.id_registro
-                    ELSE NULL::character varying
-                END) AS atend_dum_invalida,
-            max(apn.primeira_data_dum_valida) AS primeira_data_dum_valida,
-            max(
-                CASE
-                    WHEN apn.data_dum_atendimento IS NOT NULL THEN apn.data_dum_atendimento
-                    ELSE NULL::date
-                END) AS maior_data_dum,
-            min(
-                CASE
-                    WHEN apn.data_dum_atendimento IS NOT NULL THEN apn.data_dum_atendimento
-                    ELSE NULL::date
-                END) AS menor_data_dum,
-            max(
-                CASE
-                    WHEN apn.data_dum_atendimento IS NOT NULL THEN apn.data_dum_atendimento
-                    ELSE NULL::date
-                END) - min(
-                CASE
-                    WHEN apn.data_dum_atendimento IS NOT NULL THEN apn.data_dum_atendimento
-                    ELSE NULL::date
-                END) AS diff_maior_menor_data_dum,
-            max(apn.primeira_data_consulta_pre_natal_com_dum) AS primeira_data_consulta_pre_natal_com_dum,
-            max(apn.data_atendimento) AS maior_data_consulta_pre_natal,
-            min(apn.data_atendimento) AS menor_data_consulta_pre_natal,
-            max(apn.data_atendimento) - min(apn.data_atendimento) AS diff_maior_menor_data_consulta_pre_natal,
-            max(apn.primeira_data_dum_valida) + '294 days'::interval AS primeira_data_dpp,
-            max(apn.data_dpp_atendimento) AS maior_data_dpp,
-            min(apn.data_dpp_atendimento) AS menor_data_dpp,
-            max(apn.data_dpp_atendimento) - min(apn.data_dpp_atendimento) AS diff_maior_menor_data_dpp
-           FROM base_atendimentos_pre_natal apn
-          GROUP BY apn.municipio_id_sus, apn.chave_gestante
-        ), validacao_registros_parto AS (
-         SELECT b.municipio_id_sus,
-            b.chave_gestante,
-            count(DISTINCT b.id_registro) AS cont_partos,
-            max(b.data_registro) AS maior_data_registro_parto,
-            min(b.data_registro) AS menor_data_registro_parto,
-            max(b.data_registro) - min(b.data_registro) AS diff_dias_primeio_ultimo_parto
-           FROM impulso_previne_dados_nominais.eventos_pre_natal b
-          WHERE b.tipo_registro::text = 'registro_de_parto'::text
-          GROUP BY b.municipio_id_sus, b.chave_gestante
-        ), validacao_registros_aborto AS (
-         SELECT b.municipio_id_sus,
-            b.chave_gestante,
-            count(DISTINCT b.id_registro) AS cont_abortos,
-            max(b.data_registro) AS maior_data_registro_aborto,
-            min(b.data_registro) AS menor_data_registro_aborto,
-            max(b.data_registro) - min(b.data_registro) AS diff_dias_primeio_ultimo_aborto
-           FROM impulso_previne_dados_nominais.eventos_pre_natal b
-          WHERE b.tipo_registro::text = 'registro_de_aborto'::text
-          GROUP BY b.municipio_id_sus, b.chave_gestante
-        ), analise_gestante AS (
-         SELECT vd.municipio_id_sus,
-            vd.chave_gestante,
-            vd.cont_data_dum_validas,
-            vd.primeira_data_dum_valida,
-            vd.primeira_data_dpp,
-            LEAST(ra.menor_data_registro_aborto::timestamp without time zone, vd.primeira_data_dpp)::date AS data_fim_primeira_gestacao,
-                CASE
-                    WHEN LEAST(ra.menor_data_registro_aborto::timestamp without time zone, vd.primeira_data_dpp) = ra.menor_data_registro_aborto THEN 'primeira_gestacao_encerrada_registro_aborto'::text
-                    WHEN LEAST(ra.menor_data_registro_aborto::timestamp without time zone, vd.primeira_data_dpp, '2300-01-01'::date::timestamp without time zone) > CURRENT_DATE THEN 'primeira_gestacao_nao_encerrada'::text
-                    WHEN LEAST(ra.menor_data_registro_aborto::timestamp without time zone, vd.primeira_data_dpp) = vd.primeira_data_dpp THEN 'primeira_gestacao_encerrada_DPP'::text
-                    ELSE NULL::text
-                END AS tipo_encerramento_primeira_gestacao,
-                CASE
-                    WHEN vd.maior_data_consulta_pre_natal >= LEAST(ra.menor_data_registro_aborto::timestamp without time zone, vd.primeira_data_dpp, '2300-01-01'::date::timestamp without time zone) THEN NULL::text
-                    WHEN LEAST(ra.menor_data_registro_aborto::timestamp without time zone, vd.primeira_data_dpp)::date IS NOT NULL THEN NULL::text
-                    WHEN vd.diff_maior_menor_data_dum > 90 OR vd.diff_maior_menor_data_consulta_pre_natal > 294 THEN 'possivel_gestante_com_duas_gestacoes_ou_erro_registro_DUM'::text
-                    WHEN (CURRENT_DATE - vd.maior_data_consulta_pre_natal) > 294 THEN 'possivel_gestante_com_gestacao_encerrada'::text
-                    ELSE NULL::text
-                END AS quant_gestacoes,
-                CASE
-                    WHEN rp.diff_dias_primeio_ultimo_parto > 180 THEN 'possibilidade_dois_partos_ou_erro_registro'::text
-                    WHEN rp.diff_dias_primeio_ultimo_parto = 0 THEN NULL::text
-                    ELSE 'possibilidade_apenas_um_parto_ou_erro_registro'::text
-                END AS tipo_registro_parto,
-                CASE
-                    WHEN ra.diff_dias_primeio_ultimo_aborto > 60 THEN 'possibilidade_dois_abortos_ou_erro_registro'::text
-                    WHEN ra.diff_dias_primeio_ultimo_aborto = 0 THEN NULL::text
-                    ELSE 'possibilidade_apenas_um_aborto_ou_erro_registro'::text
-                END AS tipo_registro_aborto
-           FROM validacao_dum vd
-             LEFT JOIN validacao_registros_parto rp ON rp.chave_gestante::text = vd.chave_gestante::text
-             LEFT JOIN validacao_registros_aborto ra ON ra.chave_gestante::text = vd.chave_gestante::text
-        ), base_atendimentos_por_gestacao AS (
-         SELECT apn.municipio_id_sus,
-            apn.chave_gestante::text || '_1'::text AS chave_gestacao,
-            'primeira_gestacao_identificada'::text AS ordem_gestacao,
-            apn.id_registro,
-            apn.chave_gestante,
-            apn.data_atendimento,
-            apn.profissional_nome_atendimento,
-            apn.data_dum_atendimento,
-            apn.data_dpp_atendimento,
-            apn.gestante_idade_gestacional,
-            apn.gestante_idade_gestacional_atendimento,
-            row_number() OVER (PARTITION BY apn.chave_gestante ORDER BY apn.id_registro) AS ordem_consulta_pre_natal_gestacao,
-            first_value(apn.data_atendimento) OVER (PARTITION BY apn.chave_gestante, apn.municipio_id_sus ORDER BY apn.data_atendimento) AS data_primeiro_atendimento,
-            first_value(apn.data_atendimento) OVER (PARTITION BY apn.chave_gestante, apn.municipio_id_sus ORDER BY apn.data_atendimento DESC) AS data_ultimo_atendimento,
-            (array_agg(apn.data_dum_atendimento) FILTER (WHERE apn.data_dum_atendimento IS NOT NULL) OVER (PARTITION BY apn.chave_gestante, apn.municipio_id_sus ORDER BY apn.data_atendimento ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING))[1] AS data_primeira_dum_valida,
-            (array_agg(apn.data_atendimento) FILTER (WHERE apn.data_dum_atendimento IS NOT NULL) OVER (PARTITION BY apn.chave_gestante, apn.municipio_id_sus ORDER BY apn.data_atendimento ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING))[1] AS data_atendimento_com_primeira_dum_valida,
-            (array_agg(apn.gestante_idade_gestacional_atendimento) FILTER (WHERE apn.data_dum_atendimento IS NOT NULL) OVER (PARTITION BY apn.chave_gestante, apn.municipio_id_sus ORDER BY apn.data_atendimento ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING))[1] AS idade_gestacional_atendimento_com_primeira_dum_valida,
-            cg.data_fim_primeira_gestacao,
-            cg.tipo_encerramento_primeira_gestacao,
-            cg.quant_gestacoes,
-            cg.tipo_registro_parto,
-            cg.tipo_registro_aborto,
-                CASE
-                    WHEN apn.data_dpp_atendimento IS NOT NULL AND apn.data_dpp_atendimento < apn.data_atendimento THEN 'registro_de_pre_natal_com_dpp_no_passado'::text
-                    ELSE NULL::text
-                END AS registro_com_dpp_passado,
-                CASE
-                    WHEN (apn.data_atendimento - cg.data_fim_primeira_gestacao) >= 0 AND (apn.data_atendimento - cg.data_fim_primeira_gestacao) <= 30 THEN 'possivel_consulta_pos_parto_ou_parto_tardio_ou_erro_DUM'::text
-                    ELSE NULL::text
-                END AS consulta_proxima_fim_gestacao
-           FROM base_atendimentos_pre_natal apn
-             JOIN analise_gestante cg ON cg.chave_gestante::text = apn.chave_gestante::text
-          WHERE apn.data_atendimento < cg.data_fim_primeira_gestacao OR cg.data_fim_primeira_gestacao IS NULL
-        UNION ALL
-         SELECT apn.municipio_id_sus,
-            apn.chave_gestante::text || '_2'::text AS chave_gestacao,
-            'segunda_gestacao_identificada'::text AS ordem_gestacao,
-            apn.id_registro,
-            apn.chave_gestante,
-            apn.data_atendimento,
-            apn.profissional_nome_atendimento,
-            apn.data_dum_atendimento,
-            apn.data_dpp_atendimento,
-            apn.gestante_idade_gestacional,
-            apn.gestante_idade_gestacional_atendimento,
-            row_number() OVER (PARTITION BY apn.chave_gestante ORDER BY apn.id_registro) AS ordem_consulta_pre_natal_gestacao,
-            first_value(apn.data_atendimento) OVER (PARTITION BY apn.chave_gestante, apn.municipio_id_sus ORDER BY apn.data_atendimento) AS data_primeiro_atendimento,
-            first_value(apn.data_atendimento) OVER (PARTITION BY apn.chave_gestante, apn.municipio_id_sus ORDER BY apn.data_atendimento DESC) AS data_ultimo_atendimento,
-            (array_agg(apn.data_dum_atendimento) FILTER (WHERE apn.data_dum_atendimento IS NOT NULL) OVER (PARTITION BY apn.chave_gestante, apn.municipio_id_sus ORDER BY apn.data_atendimento ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING))[1] AS data_primeira_dum_valida,
-            (array_agg(apn.data_atendimento) FILTER (WHERE apn.data_dum_atendimento IS NOT NULL) OVER (PARTITION BY apn.chave_gestante, apn.municipio_id_sus ORDER BY apn.data_atendimento ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING))[1] AS data_atendimento_com_primeira_dum_valida,
-            (array_agg(apn.gestante_idade_gestacional_atendimento) FILTER (WHERE apn.data_dum_atendimento IS NOT NULL) OVER (PARTITION BY apn.chave_gestante, apn.municipio_id_sus ORDER BY apn.data_atendimento ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING))[1] AS idade_gestacional_atendimento_com_primeira_dum_valida,
-            cg.data_fim_primeira_gestacao,
-            cg.tipo_encerramento_primeira_gestacao,
-            cg.quant_gestacoes,
-            cg.tipo_registro_parto,
-            cg.tipo_registro_aborto,
-                CASE
-                    WHEN apn.data_dpp_atendimento IS NOT NULL AND apn.data_dpp_atendimento < apn.data_atendimento THEN 'registro_de_pre_natal_com_dpp_no_passado'::text
-                    ELSE NULL::text
-                END AS registro_com_dpp_passado,
-                CASE
-                    WHEN (apn.data_atendimento - cg.data_fim_primeira_gestacao) >= 0 AND (apn.data_atendimento - cg.data_fim_primeira_gestacao) <= 30 THEN 'possivel_consulta_pos_parto_ou_parto_tardio_ou_erro_DUM'::text
-                    ELSE NULL::text
-                END AS consulta_proxima_fim_gestacao
-           FROM base_atendimentos_pre_natal apn
-             JOIN analise_gestante cg ON cg.chave_gestante::text = apn.chave_gestante::text
-          WHERE apn.data_atendimento >= cg.data_fim_primeira_gestacao
-        ), infos_gestante_atendimento_individual_recente AS (
-         WITH base AS (
-                 SELECT b.municipio_id_sus,
-                    b.chave_gestante,
-                    b.gestante_nome,
-                    b.gestante_data_de_nascimento,
-                    (array_agg(b.gestante_documento_cpf) FILTER (WHERE b.gestante_documento_cpf IS NOT NULL) OVER (PARTITION BY b.chave_gestante, b.municipio_id_sus ORDER BY b.data_registro DESC))[1] AS gestante_documento_cpf,
-                    (array_agg(b.gestante_documento_cns) FILTER (WHERE b.gestante_documento_cns IS NOT NULL) OVER (PARTITION BY b.chave_gestante, b.municipio_id_sus ORDER BY b.data_registro DESC))[1] AS gestante_documento_cns,
-                    b.gestante_telefone,
-                    b.estabelecimento_cnes_atendimento,
-                    b.estabelecimento_nome_atendimento,
-                    b.equipe_ine_atendimento,
-                    b.equipe_nome_atendimento,
-                    b.data_ultimo_cadastro_individual,
-                    b.estabelecimento_cnes_cad_indivual,
-                    b.estabelecimento_nome_cad_individual,
-                    b.equipe_ine_cad_individual,
-                    b.equipe_nome_cad_individual,
-                    b.acs_cad_individual,
-                    b.data_ultima_visita_acs,
-                    b.acs_visita_domiciliar,
-                    b.acs_cad_dom_familia,
-                    row_number() OVER (PARTITION BY b.chave_gestante, b.municipio_id_sus ORDER BY b.id_registro DESC) = 1 AS ultimo_atendimento_individual
-                   FROM impulso_previne_dados_nominais.eventos_pre_natal b
-                  WHERE b.tipo_registro::text = 'consulta_pre_natal'::text
-                )
-         SELECT base.municipio_id_sus,
-            base.chave_gestante,
-            base.gestante_nome,
-            base.gestante_data_de_nascimento,
-            base.gestante_documento_cpf,
-            base.gestante_documento_cns,
-            base.gestante_telefone,
-            base.estabelecimento_cnes_atendimento,
-            base.estabelecimento_nome_atendimento,
-            base.equipe_ine_atendimento,
-            base.equipe_nome_atendimento,
-            base.data_ultimo_cadastro_individual,
-            base.estabelecimento_cnes_cad_indivual,
-            base.estabelecimento_nome_cad_individual,
-            base.equipe_ine_cad_individual,
-            base.equipe_nome_cad_individual,
-            base.acs_cad_individual,
-            base.data_ultima_visita_acs,
-            base.acs_visita_domiciliar,
-            base.acs_cad_dom_familia,
-            base.ultimo_atendimento_individual
-           FROM base
-          WHERE base.ultimo_atendimento_individual IS TRUE
-        ), base_final_gestacoes AS (
-         SELECT bag.municipio_id_sus,
-            bag.chave_gestacao,
-            bag.ordem_gestacao,
-            bag.chave_gestante,
-            ig.gestante_telefone,
-            ig.gestante_nome,
-            ig.gestante_data_de_nascimento,
-            COALESCE(NULLIF(ig.estabelecimento_cnes_cad_indivual::text, '-'::text), ig.estabelecimento_cnes_atendimento::text) AS estabelecimento_cnes,
-            upper(COALESCE(NULLIF(ig.estabelecimento_nome_cad_individual::text, 'Não informado'::text), ig.estabelecimento_nome_atendimento::text)) AS estabelecimento_nome,
-            COALESCE(NULLIF(ig.equipe_ine_cad_individual::text, '-'::text), ig.equipe_ine_atendimento::text) AS equipe_ine,
-            upper(COALESCE(NULLIF(ig.equipe_nome_cad_individual::text, 'SEM EQUIPE'::text), ig.equipe_nome_atendimento::text)) AS equipe_nome,
-            upper(COALESCE(ig.acs_visita_domiciliar, ig.acs_cad_individual, 'SEM ACS'::character varying)::text) AS acs_nome,
-            ig.data_ultima_visita_acs AS acs_data_ultima_visita,
-            bag.data_atendimento_com_primeira_dum_valida,
-            bag.data_primeira_dum_valida AS gestacao_data_dum,
-            (bag.data_primeira_dum_valida + '294 days'::interval)::date AS gestacao_data_dpp,
-            (bag.data_primeira_dum_valida + '294 days'::interval)::date - CURRENT_DATE AS gestacao_dpp_dias_para,
-                CASE
-                    WHEN (bag.data_primeira_dum_valida + '294 days'::interval)::date >= '2022-01-01'::date AND (bag.data_primeira_dum_valida + '294 days'::interval)::date <= '2022-04-30'::date THEN '2022.Q1'::text
-                    WHEN (bag.data_primeira_dum_valida + '294 days'::interval)::date >= '2022-05-01'::date AND (bag.data_primeira_dum_valida + '294 days'::interval)::date <= '2022-08-31'::date THEN '2022.Q2'::text
-                    WHEN (bag.data_primeira_dum_valida + '294 days'::interval)::date >= '2022-09-01'::date AND (bag.data_primeira_dum_valida + '294 days'::interval)::date <= '2022-12-31'::date THEN '2022.Q3'::text
-                    WHEN (bag.data_primeira_dum_valida + '294 days'::interval)::date >= '2023-01-01'::date AND (bag.data_primeira_dum_valida + '294 days'::interval)::date <= '2023-04-30'::date THEN '2023.Q1'::text
-                    WHEN (bag.data_primeira_dum_valida + '294 days'::interval)::date >= '2023-05-01'::date AND (bag.data_primeira_dum_valida + '294 days'::interval)::date <= '2023-08-31'::date THEN '2023.Q2'::text
-                    WHEN (bag.data_primeira_dum_valida + '294 days'::interval)::date >= '2023-09-01'::date AND (bag.data_primeira_dum_valida + '294 days'::interval)::date <= '2023-12-31'::date THEN '2023.Q3'::text
-                    WHEN (bag.data_primeira_dum_valida + '294 days'::interval)::date >= '2024-01-01'::date AND (bag.data_primeira_dum_valida + '294 days'::interval)::date <= '2024-04-30'::date THEN '2024.Q1'::text
-                    WHEN (bag.data_primeira_dum_valida + '294 days'::interval)::date >= '2024-05-01'::date AND (bag.data_primeira_dum_valida + '294 days'::interval)::date <= '2024-08-31'::date THEN '2024.Q2'::text
-                    WHEN (bag.data_primeira_dum_valida + '294 days'::interval)::date >= '2024-09-01'::date AND (bag.data_primeira_dum_valida + '294 days'::interval)::date <= '2024-12-31'::date THEN '2024.Q3'::text
-                    WHEN (bag.data_primeira_dum_valida + '294 days'::interval)::date >= '2025-01-01'::date AND (bag.data_primeira_dum_valida + '294 days'::interval)::date <= '2025-04-30'::date THEN '2025.Q1'::text
-                    WHEN (bag.data_primeira_dum_valida + '294 days'::interval)::date >= '2025-05-01'::date AND (bag.data_primeira_dum_valida + '294 days'::interval)::date <= '2025-08-31'::date THEN '2025.Q2'::text
-                    WHEN (bag.data_primeira_dum_valida + '294 days'::interval)::date >= '2025-09-01'::date AND (bag.data_primeira_dum_valida + '294 days'::interval)::date <= '2025-08-31'::date THEN '2025.Q3'::text
-                    ELSE 'SEM QUADRI'::text
-                END AS gestacao_quadrimestre,
-            bag.idade_gestacional_atendimento_com_primeira_dum_valida AS gestacao_idade_gestacional_primeiro_atendimento,
-            bag.data_primeiro_atendimento AS consulta_prenatal_primeira_data,
-            bag.data_ultimo_atendimento AS consulta_prenatal_ultima_data,
-            CURRENT_DATE - bag.data_ultimo_atendimento AS consulta_prenatal_ultima_dias_desde,
-            bag.data_fim_primeira_gestacao,
-            bag.tipo_encerramento_primeira_gestacao,
-            ig.gestante_documento_cpf,
-            ig.gestante_documento_cns,
-            min(
-                CASE
-                    WHEN bag.data_dum_atendimento IS NOT NULL THEN bag.ordem_consulta_pre_natal_gestacao
-                    ELSE NULL::bigint
-                END) AS ordem_primeira_consulta_com_dum,
-            max(bag.gestante_idade_gestacional) AS gestacao_idade_gestacional_atual,
-            concat(max(bag.quant_gestacoes), ', ', max(bag.tipo_registro_parto), ', ', max(bag.tipo_registro_aborto), ', ', max(bag.registro_com_dpp_passado), ', ', max(bag.consulta_proxima_fim_gestacao)) AS sinalizacao_erro_registro,
-                CASE
-                    WHEN count(DISTINCT bag.data_dum_atendimento) = 0 THEN 'somente_DUMs_invalidas'::text
-                    WHEN count(DISTINCT bag.data_dum_atendimento) > 1 THEN 'mais_de_uma_DUM_valida'::text
-                    WHEN count(DISTINCT bag.data_dum_atendimento) = 1 THEN 'uma_DUM_valida'::text
-                    ELSE NULL::text
-                END AS gestacao_qtde_dums,
-            count(DISTINCT bag.id_registro) AS consultas_prenatal_total,
-            count(DISTINCT
-                CASE
-                    WHEN bag.data_atendimento >= bag.data_atendimento_com_primeira_dum_valida AND (bag.profissional_nome_atendimento::text <> ALL (ARRAY['Não informado'::character varying::text, 'PROFISSIONAL NÃO CADASTRADO'::character varying::text])) THEN bag.id_registro
-                    ELSE NULL::character varying
-                END) AS consultas_pre_natal_validas,
-            count(
-                CASE
-                    WHEN bag.ordem_gestacao = 'primeira_gestacao_identificada'::text AND odonto.data_registro >= bag.data_primeira_dum_valida AND odonto.data_registro <= bag.data_fim_primeira_gestacao THEN odonto.data_registro
-                    WHEN bag.ordem_gestacao = 'segunda_gestacao_identificada'::text AND odonto.data_registro >= bag.data_primeira_dum_valida AND odonto.data_registro <= (bag.data_primeira_dum_valida + '294 days'::interval)::date THEN odonto.data_registro
-                    WHEN bag.data_fim_primeira_gestacao IS NULL AND odonto.data_registro >= bag.data_primeiro_atendimento THEN odonto.data_registro
-                    ELSE NULL::date
-                END) > 0 AS atendimento_odontologico_realizado,
-            count(
-                CASE
-                    WHEN bag.ordem_gestacao = 'primeira_gestacao_identificada'::text AND hiv.data_registro >= bag.data_primeira_dum_valida AND hiv.data_registro <= bag.data_fim_primeira_gestacao THEN hiv.data_registro
-                    WHEN bag.ordem_gestacao = 'segunda_gestacao_identificada'::text AND hiv.data_registro >= bag.data_primeira_dum_valida AND hiv.data_registro <= (bag.data_primeira_dum_valida + '294 days'::interval)::date THEN hiv.data_registro
-                    WHEN bag.data_fim_primeira_gestacao IS NULL AND hiv.data_registro >= bag.data_primeiro_atendimento THEN hiv.data_registro
-                    ELSE NULL::date
-                END) > 0 AS exame_hiv_realizado,
-            count(
-                CASE
-                    WHEN bag.ordem_gestacao = 'primeira_gestacao_identificada'::text AND sifilis.data_registro >= bag.data_primeira_dum_valida AND sifilis.data_registro <= bag.data_fim_primeira_gestacao THEN sifilis.data_registro
-                    WHEN bag.ordem_gestacao = 'segunda_gestacao_identificada'::text AND sifilis.data_registro >= bag.data_primeira_dum_valida AND sifilis.data_registro <= (bag.data_primeira_dum_valida + '294 days'::interval)::date THEN sifilis.data_registro
-                    WHEN bag.data_fim_primeira_gestacao IS NULL AND sifilis.data_registro >= bag.data_primeiro_atendimento THEN sifilis.data_registro
-                    ELSE NULL::date
-                END) > 0 AS exame_sifilis_realizado,
-                CASE
-                    WHEN count(
-                    CASE
-                        WHEN bag.ordem_gestacao = 'primeira_gestacao_identificada'::text AND aborto.data_registro <= bag.data_fim_primeira_gestacao THEN aborto.data_registro
-                        WHEN bag.ordem_gestacao = 'segunda_gestacao_identificada'::text AND aborto.data_registro > bag.data_fim_primeira_gestacao THEN aborto.data_registro
-                        ELSE NULL::date
-                    END) > 0 THEN 'Sim'::text
-                    ELSE 'Não'::text
-                END AS possui_registro_aborto,
-                CASE
-                    WHEN count(
-                    CASE
-                        WHEN bag.ordem_gestacao = 'primeira_gestacao_identificada'::text AND parto.data_registro <= (bag.data_fim_primeira_gestacao + '180 days'::interval) THEN parto.data_registro
-                        WHEN bag.ordem_gestacao = 'segunda_gestacao_identificada'::text AND parto.data_registro > (bag.data_fim_primeira_gestacao + '180 days'::interval) THEN parto.data_registro
-                        ELSE NULL::date
-                    END) > 0 THEN 'Sim'::text
-                    ELSE 'Não'::text
-                END AS possui_registro_parto
-           FROM base_atendimentos_por_gestacao bag
-             LEFT JOIN infos_gestante_atendimento_individual_recente ig ON bag.chave_gestante::text = ig.chave_gestante::text
-             LEFT JOIN impulso_previne_dados_nominais.eventos_pre_natal odonto ON bag.chave_gestante::text = odonto.chave_gestante::text AND odonto.tipo_registro::text = 'atendimento_odontologico'::text
-             LEFT JOIN impulso_previne_dados_nominais.eventos_pre_natal sifilis ON bag.chave_gestante::text = sifilis.chave_gestante::text AND (sifilis.tipo_registro::text = ANY (ARRAY['teste_rapido_exame_sifilis'::character varying::text, 'exame_sifilis_avaliado'::character varying::text]))
-             LEFT JOIN impulso_previne_dados_nominais.eventos_pre_natal hiv ON bag.chave_gestante::text = hiv.chave_gestante::text AND (hiv.tipo_registro::text = ANY (ARRAY['teste_rapido_exame_hiv'::character varying::text, 'exame_hiv_avaliado'::character varying::text]))
-             LEFT JOIN impulso_previne_dados_nominais.eventos_pre_natal parto ON bag.chave_gestante::text = parto.chave_gestante::text AND parto.tipo_registro::text = 'registro_de_parto'::text
-             LEFT JOIN impulso_previne_dados_nominais.eventos_pre_natal aborto ON bag.chave_gestante::text = aborto.chave_gestante::text AND aborto.tipo_registro::text = 'registro_de_aborto'::text
-          GROUP BY bag.municipio_id_sus, bag.chave_gestacao, bag.ordem_gestacao, bag.chave_gestante, ig.gestante_telefone, ig.gestante_nome, ig.gestante_data_de_nascimento, (COALESCE(NULLIF(ig.estabelecimento_cnes_cad_indivual::text, '-'::text), ig.estabelecimento_cnes_atendimento::text)), (upper(COALESCE(NULLIF(ig.estabelecimento_nome_cad_individual::text, 'Não informado'::text), ig.estabelecimento_nome_atendimento::text))), (COALESCE(NULLIF(ig.equipe_ine_cad_individual::text, '-'::text), ig.equipe_ine_atendimento::text)), (upper(COALESCE(NULLIF(ig.equipe_nome_cad_individual::text, 'SEM EQUIPE'::text), ig.equipe_nome_atendimento::text))), (upper(COALESCE(ig.acs_visita_domiciliar, ig.acs_cad_individual, 'SEM ACS'::character varying)::text)), ig.data_ultima_visita_acs, bag.data_primeira_dum_valida, ((bag.data_primeira_dum_valida + '294 days'::interval)::date), ((bag.data_primeira_dum_valida + '294 days'::interval)::date - CURRENT_DATE), (
-                CASE
-                    WHEN (bag.data_primeira_dum_valida + '294 days'::interval)::date >= '2022-01-01'::date AND (bag.data_primeira_dum_valida + '294 days'::interval)::date <= '2022-04-30'::date THEN '2022.Q1'::text
-                    WHEN (bag.data_primeira_dum_valida + '294 days'::interval)::date >= '2022-05-01'::date AND (bag.data_primeira_dum_valida + '294 days'::interval)::date <= '2022-08-31'::date THEN '2022.Q2'::text
-                    WHEN (bag.data_primeira_dum_valida + '294 days'::interval)::date >= '2022-09-01'::date AND (bag.data_primeira_dum_valida + '294 days'::interval)::date <= '2022-12-31'::date THEN '2022.Q3'::text
-                    WHEN (bag.data_primeira_dum_valida + '294 days'::interval)::date >= '2023-01-01'::date AND (bag.data_primeira_dum_valida + '294 days'::interval)::date <= '2023-04-30'::date THEN '2023.Q1'::text
-                    WHEN (bag.data_primeira_dum_valida + '294 days'::interval)::date >= '2023-05-01'::date AND (bag.data_primeira_dum_valida + '294 days'::interval)::date <= '2023-08-31'::date THEN '2023.Q2'::text
-                    WHEN (bag.data_primeira_dum_valida + '294 days'::interval)::date >= '2023-09-01'::date AND (bag.data_primeira_dum_valida + '294 days'::interval)::date <= '2023-12-31'::date THEN '2023.Q3'::text
-                    WHEN (bag.data_primeira_dum_valida + '294 days'::interval)::date >= '2024-01-01'::date AND (bag.data_primeira_dum_valida + '294 days'::interval)::date <= '2024-04-30'::date THEN '2024.Q1'::text
-                    WHEN (bag.data_primeira_dum_valida + '294 days'::interval)::date >= '2024-05-01'::date AND (bag.data_primeira_dum_valida + '294 days'::interval)::date <= '2024-08-31'::date THEN '2024.Q2'::text
-                    WHEN (bag.data_primeira_dum_valida + '294 days'::interval)::date >= '2024-09-01'::date AND (bag.data_primeira_dum_valida + '294 days'::interval)::date <= '2024-12-31'::date THEN '2024.Q3'::text
-                    WHEN (bag.data_primeira_dum_valida + '294 days'::interval)::date >= '2025-01-01'::date AND (bag.data_primeira_dum_valida + '294 days'::interval)::date <= '2025-04-30'::date THEN '2025.Q1'::text
-                    WHEN (bag.data_primeira_dum_valida + '294 days'::interval)::date >= '2025-05-01'::date AND (bag.data_primeira_dum_valida + '294 days'::interval)::date <= '2025-08-31'::date THEN '2025.Q2'::text
-                    WHEN (bag.data_primeira_dum_valida + '294 days'::interval)::date >= '2025-09-01'::date AND (bag.data_primeira_dum_valida + '294 days'::interval)::date <= '2025-08-31'::date THEN '2025.Q3'::text
-                    ELSE 'SEM QUADRI'::text
-                END), bag.idade_gestacional_atendimento_com_primeira_dum_valida, bag.data_primeiro_atendimento, bag.data_ultimo_atendimento, (CURRENT_DATE - bag.data_ultimo_atendimento), bag.data_fim_primeira_gestacao, bag.tipo_encerramento_primeira_gestacao, ig.gestante_documento_cpf, ig.gestante_documento_cns, bag.data_atendimento_com_primeira_dum_valida
-        )
- SELECT base_final_gestacoes.municipio_id_sus,
-    base_final_gestacoes.chave_gestacao,
-    base_final_gestacoes.ordem_gestacao,
-    base_final_gestacoes.chave_gestante,
-    base_final_gestacoes.gestante_telefone,
-    base_final_gestacoes.gestante_nome,
-    base_final_gestacoes.gestante_data_de_nascimento,
-    base_final_gestacoes.estabelecimento_cnes,
-    base_final_gestacoes.estabelecimento_nome,
-    base_final_gestacoes.equipe_ine,
-    base_final_gestacoes.equipe_nome,
-    base_final_gestacoes.acs_nome,
-    base_final_gestacoes.acs_data_ultima_visita,
-    base_final_gestacoes.ordem_primeira_consulta_com_dum,
-    base_final_gestacoes.data_atendimento_com_primeira_dum_valida,
-    base_final_gestacoes.gestacao_data_dum,
-    base_final_gestacoes.gestacao_data_dpp,
-    base_final_gestacoes.gestacao_dpp_dias_para,
-    base_final_gestacoes.gestacao_quadrimestre,
-    base_final_gestacoes.gestacao_idade_gestacional_primeiro_atendimento,
-    base_final_gestacoes.consulta_prenatal_primeira_data,
-    base_final_gestacoes.consulta_prenatal_ultima_data,
-    base_final_gestacoes.consulta_prenatal_ultima_dias_desde,
-    base_final_gestacoes.data_fim_primeira_gestacao,
-    base_final_gestacoes.tipo_encerramento_primeira_gestacao,
-    base_final_gestacoes.gestante_documento_cpf,
-    base_final_gestacoes.gestante_documento_cns,
-    base_final_gestacoes.gestacao_idade_gestacional_atual,
-    base_final_gestacoes.sinalizacao_erro_registro,
-    base_final_gestacoes.gestacao_qtde_dums,
-    base_final_gestacoes.consultas_prenatal_total,
-    base_final_gestacoes.consultas_pre_natal_validas,
-    base_final_gestacoes.atendimento_odontologico_realizado,
-    base_final_gestacoes.exame_hiv_realizado,
-    base_final_gestacoes.exame_sifilis_realizado,
-    base_final_gestacoes.possui_registro_aborto,
-    base_final_gestacoes.possui_registro_parto,
+        FROM base b
+        --select * from base_atendimentos_pre_natal
+)
+, validacao_dum AS (
+-- Análise da data de DUM que é a base para definição do fim e início das gestacoes
+    SELECT 
+        apn.chave_gestante,
+        COUNT(DISTINCT apn.id_registro) AS consultas_pre_natal,
+        COUNT(DISTINCT CASE WHEN apn.data_dum_atendimento IS NOT NULL THEN apn.data_dum_atendimento END) AS cont_data_dum_validas,
+        COUNT(DISTINCT CASE WHEN apn.data_dum_atendimento IS NULL THEN apn.id_registro END) AS atend_dum_invalida,
+        MAX(apn.primeira_data_dum_valida) AS primeira_data_dum_valida,
+        MAX(CASE WHEN apn.data_dum_atendimento IS NOT NULL THEN data_dum_atendimento END) AS maior_data_dum,
+        MIN(CASE WHEN apn.data_dum_atendimento IS NOT NULL THEN data_dum_atendimento END) AS menor_data_dum,
+        MAX(CASE WHEN apn.data_dum_atendimento IS NOT NULL THEN data_dum_atendimento END)- MIN(CASE WHEN apn.data_dum_atendimento IS NOT NULL THEN apn.data_dum_atendimento END) AS diff_maior_menor_data_dum, 
+        MAX(apn.primeira_data_consulta_pre_natal_com_DUM) AS primeira_data_consulta_pre_natal_com_DUM,
+        MAX(apn.data_atendimento) AS maior_data_consulta_pre_natal,
+        MIN(apn.data_atendimento) AS menor_data_consulta_pre_natal,
+        MAX(apn.data_atendimento)- MIN(apn.data_atendimento) AS diff_maior_menor_data_consulta_pre_natal,
+        MAX(apn.primeira_data_dum_valida) + '294 days'::INTERVAL AS primeira_data_dpp,
+        MAX(apn.data_dpp_atendimento)::date AS maior_data_dpp,
+        MIN(apn.data_dpp_atendimento)::date AS menor_data_dpp,
+        MAX(apn.data_dpp_atendimento)::date - MIN(apn.data_dpp_atendimento)::date AS diff_maior_menor_data_dpp
+    FROM base_atendimentos_pre_natal apn
+    GROUP BY 1
+) 
+, validacao_registros_parto AS (
+    SELECT
+        b.chave_gestante,
+        COUNT(DISTINCT b.id_registro) AS cont_partos,
+        MAX(b.data_registro) AS maior_data_registro_parto,
+        MIN(b.data_registro) AS menor_data_registro_parto,
+        MAX(b.data_registro) - MIN(b.data_registro) AS diff_dias_primeio_ultimo_parto       
+    FROM impulso_previne_dados_nominais.eventos_pre_natal b
+    WHERE b.tipo_registro = 'registro_de_parto'
+    GROUP BY 1
+        )   
+, validacao_registros_aborto AS (
+    SELECT
+        b.chave_gestante,
+        COUNT(DISTINCT b.id_registro) AS cont_abortos,
+        MAX(b.data_registro) AS maior_data_registro_aborto,
+        MIN(b.data_registro) AS menor_data_registro_aborto,
+        MAX(b.data_registro) - MIN(b.data_registro) AS diff_dias_primeio_ultimo_aborto
+    FROM impulso_previne_dados_nominais.eventos_pre_natal b
+    WHERE b.tipo_registro = 'registro_de_aborto'
+    GROUP BY 1
+)
+, analise_gestante AS (
+-- Criação de variáveis para entendimento do histórico de gestações por gestante e possíveis erros/falhas de registro
+    SELECT
+        vd.chave_gestante,
+        vd.cont_data_dum_validas,
+        vd.primeira_data_dum_valida,
+        vd.primeira_data_dpp,
+        -- Definição da data de fim da gestacao (somente eventos identificados e considerados pelo SISAB)
+        LEAST(ra.menor_data_registro_aborto,vd.primeira_data_dpp)::date AS data_fim_primeira_gestacao,
+        CASE 
+            WHEN LEAST(ra.menor_data_registro_aborto,vd.primeira_data_dpp) = ra.menor_data_registro_aborto 
+                THEN 'primeira_gestacao_encerrada_registro_aborto'
+            WHEN LEAST(ra.menor_data_registro_aborto,vd.primeira_data_dpp,'2300-01-01'::date) > CURRENT_DATE 
+                THEN 'primeira_gestacao_nao_encerrada'
+            WHEN LEAST(ra.menor_data_registro_aborto,vd.primeira_data_dpp) = vd.primeira_data_dpp 
+                THEN 'primeira_gestacao_encerrada_DPP'
+        END AS tipo_encerramento_primeira_gestacao,
+        -- Nos casos de gestantes com um histórico de atendimentos numa janela maior que 9 meses ou mais de um registro de data de DUM com intervalos maiores que
+        -- 3 meses sem identificação correta de fim de gestação, há possibilidade de erros de registros ou segunda gestação não sinalizada
+        -- Nesses casos não inferimos datas de fim e de início, porém sinalizamos possivel erro no registro da gestante
         CASE
-            WHEN base_final_gestacoes.exame_sifilis_realizado IS TRUE AND base_final_gestacoes.exame_hiv_realizado IS TRUE THEN true
-            ELSE false
-        END AS exame_sifilis_hiv_realizado,
+            WHEN vd.maior_data_consulta_pre_natal >= LEAST(ra.menor_data_registro_aborto,vd.primeira_data_dpp, '2300-01-01'::date)
+                THEN NULL 
+            WHEN LEAST(ra.menor_data_registro_aborto,vd.primeira_data_dpp)::date IS NOT NULL  
+                THEN NULL 
+            WHEN vd.diff_maior_menor_data_dum > 90 OR vd.diff_maior_menor_data_consulta_pre_natal > 294
+                THEN 'possivel_gestante_com_duas_gestacoes_ou_erro_registro_DUM'
+            WHEN CURRENT_DATE - vd.maior_data_consulta_pre_natal > 294
+                THEN 'possivel_gestante_com_gestacao_encerrada'
+        END AS quant_gestacoes,
+        -- Temos casos de gestante com mais de um parto - datas próximas, ou possível indicação de registros duplicados
+        CASE 
+            WHEN diff_dias_primeio_ultimo_parto > 180 
+                THEN 'possibilidade_dois_partos_ou_erro_registro'
+            WHEN diff_dias_primeio_ultimo_parto = 0
+                THEN 'apenas_um_parto'
+            ELSE 'possibilidade_apenas_um_parto_ou_erro_registro'
+        END AS tipo_registro_parto,
+        -- Temos casos de gestante com mais de um aborto - datas próximas, ou possível indicação de registros duplicados
+        CASE 
+            WHEN diff_dias_primeio_ultimo_aborto > 60 
+                THEN 'possibilidade_dois_abortos_ou_erro_registro'
+            WHEN diff_dias_primeio_ultimo_aborto = 0
+                THEN 'apenas_um_aborto'
+            ELSE 'possibilidade_apenas_um_aborto_ou_erro_registro'
+        END AS tipo_registro_aborto 
+    FROM validacao_dum vd 
+    LEFT JOIN validacao_registros_parto rp 
+        ON rp.chave_gestante = vd.chave_gestante
+    LEFT JOIN validacao_registros_aborto ra 
+        ON ra.chave_gestante = vd.chave_gestante
+)
+, base_atendimentos_por_gestacao AS (
+/*
+    As gestacoes sao identificadas a partir da data_fim_primeira_gestacao. 
+    Todos os registros que ocorrem ANTES dessa data entram para a PRIMEIRA GESTAÇÃO
+    Todos os registros que ocorrem DEPOIS dessa data entram para a SEGUNDA GESTAÇÃO
+    Nos casos de gestantes com apenas DUMs invalidas - todos os registros entram para a PRIMEIRA GESTAÇÃO
+*/
+-- PRIMEIRA GESTACAO IDENTIFICADA
+    SELECT
+        apn.chave_gestante||'_1' AS chave_gestacao,
+        'primeira_gestacao_identificada' AS ordem_gestacao,
+        apn.id_registro,
+        apn.chave_gestante,
+        apn.data_atendimento,
+        apn.profissional_nome_atendimento,
+        apn.data_dum_atendimento,
+        apn.data_dpp_atendimento,
+        apn.gestante_idade_gestacional,
+        apn.gestante_idade_gestacional_atendimento,
+        FIRST_VALUE(apn.data_atendimento) OVER (PARTITION BY apn.chave_gestante ORDER BY apn.data_atendimento) AS data_primeiro_atendimento,
+        FIRST_VALUE(apn.data_atendimento) OVER (PARTITION BY apn.chave_gestante ORDER BY apn.data_atendimento desc) AS data_ultimo_atendimento,
+        (array_agg(apn.data_dum_atendimento) FILTER (WHERE apn.data_dum_atendimento IS NOT NULL) OVER (PARTITION BY apn.chave_gestante ORDER BY apn.data_atendimento ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING))[1] AS data_primeira_DUM_valida,
+        (array_agg(apn.data_atendimento) FILTER (WHERE apn.data_dum_atendimento IS NOT NULL) OVER (PARTITION BY apn.chave_gestante ORDER BY apn.data_atendimento ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING))[1] AS data_atendimento_com_primeira_DUM_valida,
+        (array_agg(apn.gestante_idade_gestacional_atendimento) FILTER (WHERE apn.data_dum_atendimento IS NOT NULL) OVER (PARTITION BY apn.chave_gestante ORDER BY apn.data_atendimento ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING))[1] AS idade_gestacional_atendimento_com_primeira_DUM_valida,
+        (array_agg(apn.gestante_idade_gestacional) FILTER (WHERE apn.data_dum_atendimento IS NOT NULL) OVER (PARTITION BY apn.chave_gestante ORDER BY apn.data_atendimento ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING))[1] AS idade_gestacional_atual_com_primeira_DUM_valida,
+        cg.data_fim_primeira_gestacao,
+        cg.tipo_encerramento_primeira_gestacao,
+        cg.quant_gestacoes,
+        cg.tipo_registro_parto, 
+        cg.tipo_registro_aborto,    
+        CASE 
+            WHEN apn.data_dpp_atendimento IS NOT NULL AND apn.data_dpp_atendimento < apn.data_atendimento
+                THEN 'registro_de_pre_natal_com_dpp_no_passado'
+        END AS registro_com_dpp_passado,
+        CASE 
+            WHEN apn.data_atendimento - cg.data_fim_primeira_gestacao BETWEEN 0 AND 30 
+                THEN 'possivel_consulta_pos_parto_ou_parto_tardio_ou_erro_DUM'
+        END AS consulta_proxima_fim_gestacao 
+    FROM base_atendimentos_pre_natal apn
+    JOIN analise_gestante cg 
+        ON cg.chave_gestante = apn.chave_gestante
+    WHERE apn.data_atendimento < cg.data_fim_primeira_gestacao
+        OR cg.data_fim_primeira_gestacao IS NULL -- Gestantes com DUM inválidas sem registro de fim de gestacao
+UNION ALL 
+-- SEGUNDA GESTACAO IDENTIFICADA
+    SELECT
+        apn.chave_gestante||'_2' AS chave_gestacao,
+        'segunda_gestacao_identificada' AS ordem_gestacao,
+        apn.id_registro,
+        apn.chave_gestante,
+        apn.data_atendimento,
+        apn.profissional_nome_atendimento,
+        apn.data_dum_atendimento,
+        apn.data_dpp_atendimento,
+        apn.gestante_idade_gestacional,
+        apn.gestante_idade_gestacional_atendimento,
+        FIRST_VALUE(apn.data_atendimento) OVER (PARTITION BY apn.chave_gestante ORDER BY apn.data_atendimento) AS data_primeiro_atendimento,
+        FIRST_VALUE(apn.data_atendimento) OVER (PARTITION BY apn.chave_gestante ORDER BY apn.data_atendimento desc) AS data_ultimo_atendimento,
+        (array_agg(apn.data_dum_atendimento) FILTER (WHERE apn.data_dum_atendimento IS NOT NULL) OVER (PARTITION BY apn.chave_gestante ORDER BY apn.data_atendimento ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING))[1] AS data_primeira_DUM_valida,
+        (array_agg(apn.data_atendimento) FILTER (WHERE apn.data_dum_atendimento IS NOT NULL) OVER (PARTITION BY apn.chave_gestante ORDER BY apn.data_atendimento ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING))[1] AS data_atendimento_com_primeira_DUM_valida,
+        (array_agg(apn.gestante_idade_gestacional_atendimento) FILTER (WHERE apn.data_dum_atendimento IS NOT NULL) OVER (PARTITION BY apn.chave_gestante ORDER BY apn.data_atendimento ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING))[1] AS idade_gestacional_atendimento_com_primeira_DUM_valida,
+        (array_agg(apn.gestante_idade_gestacional) FILTER (WHERE apn.data_dum_atendimento IS NOT NULL) OVER (PARTITION BY apn.chave_gestante ORDER BY apn.data_atendimento ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING))[1] AS idade_gestacional_atual_com_primeira_DUM_valida,
+        cg.data_fim_primeira_gestacao,
+        cg.tipo_encerramento_primeira_gestacao,
+        cg.quant_gestacoes,
+        cg.tipo_registro_parto, 
+        cg.tipo_registro_aborto,
+        -- Há casos de registros de DUM que acarretam em datas de DPP anteriores a data de atendimento do pré-natal. 
+        -- Nesse caso o pré-natal registrado indica uma gestacao que já ocorreu, nao sendo possivel contabilizar nos indicadores de pré-natal 
+        -- OBS: gestantes que fizeram uso de metodos contraceptivos que interropem a menstruacao por muito tempo podem entrar nesses casos.
+        CASE 
+            WHEN apn.data_dpp_atendimento IS NOT NULL AND apn.data_dpp_atendimento < apn.data_atendimento
+                THEN 'registro_de_pre_natal_com_dpp_no_passado'
+        END AS registro_com_dpp_passado,
+        -- Há casos de consultas de pré natal logo após o encerramento da gestacao. 
+        -- Nesse caso o SISAB contabiliza como uma nova gestacao. Mas existem casos de parto tardio ou consulta de pos-parto mal registrada ou erro de DUM
+        CASE 
+            WHEN apn.data_atendimento - cg.data_fim_primeira_gestacao BETWEEN 0 AND 30 
+                THEN 'possivel_consulta_pos_parto_ou_parto_tardio_ou_erro_DUM'
+        END AS consulta_proxima_fim_gestacao
+    FROM base_atendimentos_pre_natal apn
+    JOIN analise_gestante cg 
+        ON cg.chave_gestante = apn.chave_gestante
+    WHERE apn.data_atendimento >= cg.data_fim_primeira_gestacao
+)
+, infos_gestante_atendimento_individual_recente AS (
+    WITH base AS (
+        SELECT 
+            b.chave_gestante,
+            b.gestante_nome,
+            b.gestante_data_de_nascimento,
+            (array_agg(b.gestante_documento_cpf) FILTER (WHERE b.gestante_documento_cpf IS NOT NULL) OVER (PARTITION BY b.chave_gestante ORDER BY b.data_registro DESC))[1] AS gestante_documento_cpf,
+            (array_agg(b.gestante_documento_cns) FILTER (WHERE b.gestante_documento_cns IS NOT NULL) OVER (PARTITION BY b.chave_gestante ORDER BY b.data_registro DESC))[1] AS gestante_documento_cns,
+            b.gestante_telefone,
+            b.estabelecimento_cnes_atendimento,
+            b.estabelecimento_nome_atendimento,
+            b.equipe_ine_atendimento,
+            b.equipe_nome_atendimento,
+            b.data_ultimo_cadastro_individual,
+            b.estabelecimento_cnes_cad_indivual,
+            b.estabelecimento_nome_cad_individual,
+            b.equipe_ine_cad_individual,
+            b.equipe_nome_cad_individual,
+            b.acs_cad_individual,
+            b.data_ultima_visita_acs,
+            b.acs_visita_domiciliar,
+            --b.data_ultimo_cadastro_dom_familia,
+            --b.micro_area_domicilio,
+            --b.cnes_estabelecimento_cad_dom_familia,
+            --b.estabelecimento_cad_dom_familia,
+            --b.ine_equipe_cad_dom_familia,
+            --b.equipe_cad_dom_familia,
+            b.acs_cad_dom_familia,
+            row_number() OVER (PARTITION BY b.chave_gestante ORDER BY b.id_registro DESC) = 1 AS ultimo_atendimento_individual
+        FROM impulso_previne_dados_nominais.eventos_pre_natal b
+        WHERE tipo_registro = 'consulta_pre_natal'
+    )
+SELECT * FROM base WHERE ultimo_atendimento_individual IS TRUE 
+) 
+, base_final_gestacoes AS (
+    SELECT 
+        bag.chave_gestacao,
+        bag.ordem_gestacao,
+        bag.chave_gestante,
+        ig.gestante_telefone,
+        ig.gestante_nome,
+        ig.gestante_data_de_nascimento,
+        COALESCE(NULLIF(ig.estabelecimento_cnes_cad_indivual::text, '-'::text), ig.estabelecimento_cnes_atendimento::text) AS estabelecimento_cnes,
+        UPPER(COALESCE(NULLIF(ig.estabelecimento_nome_cad_individual::text, 'Não informado'::text), ig.estabelecimento_nome_atendimento::text)) AS estabelecimento_nome,
+        COALESCE(NULLIF(ig.equipe_ine_cad_individual::text, '-'::text), ig.equipe_ine_atendimento::text) AS equipe_ine,
+        UPPER(COALESCE(NULLIF(ig.equipe_nome_cad_individual::text, 'SEM EQUIPE'::text), ig.equipe_nome_atendimento::text)) AS equipe_nome,
+        UPPER(COALESCE(ig.acs_visita_domiciliar, ig.acs_cad_individual, 'SEM ACS')) AS acs_nome,
+        ig.data_ultima_visita_acs AS acs_data_ultima_visita,
+        bag.data_primeira_DUM_valida AS gestacao_data_dum,
+        (bag.data_primeira_DUM_valida + '294 days'::INTERVAL)::DATE AS gestacao_data_dpp,
+        (bag.data_primeira_DUM_valida + '294 days'::INTERVAL)::DATE - CURRENT_DATE AS gestacao_dpp_dias_para,
+        CASE
+            WHEN (bag.data_primeira_DUM_valida + '294 days'::INTERVAL)::DATE >= '2022-01-01'::date AND (bag.data_primeira_DUM_valida + '294 days'::INTERVAL)::DATE <= '2022-04-30'::date THEN '2022.Q1'::text
+            WHEN (bag.data_primeira_DUM_valida + '294 days'::INTERVAL)::DATE >= '2022-05-01'::date AND (bag.data_primeira_DUM_valida + '294 days'::INTERVAL)::DATE <= '2022-08-31'::date THEN '2022.Q2'::text
+            WHEN (bag.data_primeira_DUM_valida + '294 days'::INTERVAL)::DATE >= '2022-09-01'::date AND (bag.data_primeira_DUM_valida + '294 days'::INTERVAL)::DATE <= '2022-12-31'::date THEN '2022.Q3'::text
+            WHEN (bag.data_primeira_DUM_valida + '294 days'::INTERVAL)::DATE >= '2023-01-01'::date AND (bag.data_primeira_DUM_valida + '294 days'::INTERVAL)::DATE <= '2023-04-30'::date THEN '2023.Q1'::text
+            WHEN (bag.data_primeira_DUM_valida + '294 days'::INTERVAL)::DATE >= '2023-05-01'::date AND (bag.data_primeira_DUM_valida + '294 days'::INTERVAL)::DATE <= '2023-08-31'::date THEN '2023.Q2'::text
+            WHEN (bag.data_primeira_DUM_valida + '294 days'::INTERVAL)::DATE >= '2023-09-01'::date AND (bag.data_primeira_DUM_valida + '294 days'::INTERVAL)::DATE <= '2023-12-31'::date THEN '2023.Q3'::text
+            WHEN (bag.data_primeira_DUM_valida + '294 days'::INTERVAL)::DATE >= '2024-01-01'::date AND (bag.data_primeira_DUM_valida + '294 days'::INTERVAL)::DATE <= '2024-04-30'::date THEN '2024.Q1'::text
+            WHEN (bag.data_primeira_DUM_valida + '294 days'::INTERVAL)::DATE >= '2024-05-01'::date AND (bag.data_primeira_DUM_valida + '294 days'::INTERVAL)::DATE <= '2024-08-31'::date THEN '2024.Q2'::text
+            WHEN (bag.data_primeira_DUM_valida + '294 days'::INTERVAL)::DATE >= '2024-09-01'::date AND (bag.data_primeira_DUM_valida + '294 days'::INTERVAL)::DATE <= '2024-12-31'::date THEN '2024.Q3'::text
+            WHEN (bag.data_primeira_DUM_valida + '294 days'::INTERVAL)::DATE >= '2025-01-01'::date AND (bag.data_primeira_DUM_valida + '294 days'::INTERVAL)::DATE <= '2025-04-30'::date THEN '2025.Q1'::text
+            WHEN (bag.data_primeira_DUM_valida + '294 days'::INTERVAL)::DATE >= '2025-05-01'::date AND (bag.data_primeira_DUM_valida + '294 days'::INTERVAL)::DATE <= '2025-08-31'::date THEN '2025.Q2'::text
+            WHEN (bag.data_primeira_DUM_valida + '294 days'::INTERVAL)::DATE >= '2025-09-01 '::date AND (bag.data_primeira_DUM_valida + '294 days'::INTERVAL)::DATE <= '2025-08-31'::date THEN '2025.Q3'::text
+            ELSE 'SEM QUADRI'::text
+        END AS gestacao_quadrimestre,
+        bag.idade_gestacional_atendimento_com_primeira_DUM_valida AS gestacao_idade_gestacional_primeiro_atendimento,
+        bag.data_primeiro_atendimento AS consulta_prenatal_primeira_data,
+        bag.data_ultimo_atendimento AS consulta_prenatal_ultima_data,
+        CURRENT_DATE - bag.data_ultimo_atendimento AS consulta_prenatal_ultima_dias_desde,
+        bag.data_fim_primeira_gestacao,
+        bag.tipo_encerramento_primeira_gestacao,
+        ig.gestante_documento_cpf,
+        ig.gestante_documento_cns,
+        bag.idade_gestacional_atual_com_primeira_DUM_valida AS gestacao_idade_gestacional_atual,
+        CONCAT(max(bag.quant_gestacoes),', ',max(bag.tipo_registro_parto),', ', max(bag.tipo_registro_aborto),', ',max(bag.registro_com_dpp_passado), ', ',max(consulta_proxima_fim_gestacao)) AS sinalizacao_erro_registro,
+        -- No caso de somente DUM inváidas, não inferimos datas de início e fim de gestação
+        CASE 
+            WHEN COUNT(DISTINCT bag.data_dum_atendimento)= 0
+                THEN 'somente_DUMs_invalidas'
+            WHEN COUNT(DISTINCT bag.data_dum_atendimento) > 1
+                THEN 'mais_de_uma_DUM_valida'
+            WHEN COUNT(DISTINCT bag.data_dum_atendimento) = 1
+                THEN 'uma_DUM_valida'
+        END AS gestacao_qtde_dums,
+        COUNT(DISTINCT bag.id_registro) AS consultas_prenatal_total,
+        -- O SISAB só contabiliza consultas de pré-natal a partir da consulta com a primeira DUM válida e com realizadas por profissional corretamente cadastrado
+        COUNT(DISTINCT CASE 
+                            WHEN bag.data_atendimento >= data_atendimento_com_primeira_DUM_valida 
+                                    AND bag.profissional_nome_atendimento NOT IN ('Não informado', 'PROFISSIONAL NÃO CADASTRADO') 
+                                THEN bag.id_registro 
+              END) AS consultas_pre_natal_validas,
+        -- Quando só há DUMs inválida, não há data_fim_primeira_gestacao. Nesse caso contabilizamos exames e consultas em uma gestacao apenas
+        COUNT(CASE 
+                        WHEN bag.ordem_gestacao = 'primeira_gestacao_identificada' AND odonto.data_registro BETWEEN bag.data_primeira_DUM_valida AND bag.data_fim_primeira_gestacao
+                            THEN odonto.data_registro
+                        WHEN bag.ordem_gestacao = 'segunda_gestacao_identificada' AND odonto.data_registro BETWEEN bag.data_primeira_DUM_valida AND (bag.data_primeira_DUM_valida + '294 days'::INTERVAL)::DATE
+                            THEN odonto.data_registro
+                        WHEN bag.data_fim_primeira_gestacao IS NULL AND odonto.data_registro >= bag.data_primeiro_atendimento
+                            THEN odonto.data_registro
+              END) > 0 
+        AS atendimento_odontologico_realizado,
+        COUNT(CASE 
+                    WHEN bag.ordem_gestacao = 'primeira_gestacao_identificada' AND hiv.data_registro BETWEEN bag.data_primeira_DUM_valida AND bag.data_fim_primeira_gestacao
+                        THEN hiv.data_registro
+                    WHEN bag.ordem_gestacao = 'segunda_gestacao_identificada' AND hiv.data_registro BETWEEN bag.data_primeira_DUM_valida AND (bag.data_primeira_DUM_valida + '294 days'::INTERVAL)::DATE
+                        THEN hiv.data_registro
+                    WHEN bag.data_fim_primeira_gestacao IS NULL AND hiv.data_registro >= bag.data_primeiro_atendimento
+                        THEN hiv.data_registro
+              END) > 0 
+        AS exame_hiv_realizado,
+        COUNT(CASE 
+                    WHEN bag.ordem_gestacao = 'primeira_gestacao_identificada' AND sifilis.data_registro BETWEEN bag.data_primeira_DUM_valida AND bag.data_fim_primeira_gestacao
+                        THEN sifilis.data_registro
+                    WHEN bag.ordem_gestacao = 'segunda_gestacao_identificada' AND sifilis.data_registro BETWEEN bag.data_primeira_DUM_valida AND (bag.data_primeira_DUM_valida + '294 days'::INTERVAL)::DATE
+                        THEN sifilis.data_registro
+                    WHEN bag.data_fim_primeira_gestacao IS NULL AND sifilis.data_registro >= bag.data_primeiro_atendimento
+                        THEN sifilis.data_registro
+              END) > 0 
+        AS exame_sifilis_realizado,
+        CASE
+            WHEN COUNT(CASE 
+                    WHEN bag.ordem_gestacao = 'primeira_gestacao_identificada' AND aborto.data_registro <= bag.data_fim_primeira_gestacao
+                        THEN aborto.data_registro
+                    WHEN bag.ordem_gestacao = 'segunda_gestacao_identificada' AND aborto.data_registro > bag.data_fim_primeira_gestacao
+                        THEN aborto.data_registro
+                    END) > 0 
+            THEN 'Sim'
+            ELSE 'Não'
+        END AS possui_registro_aborto,
+        CASE
+            WHEN COUNT(CASE 
+                    WHEN bag.ordem_gestacao = 'primeira_gestacao_identificada' AND (parto.data_registro <= bag.data_fim_primeira_gestacao + INTERVAL '180 days') 
+                        THEN parto.data_registro
+                    WHEN bag.ordem_gestacao = 'segunda_gestacao_identificada' AND parto.data_registro > bag.data_fim_primeira_gestacao + INTERVAL '180 days'
+                        THEN parto.data_registro
+                    END) > 0 
+            THEN 'Sim'
+            ELSE 'Não'
+        END AS possui_registro_parto
+    FROM base_atendimentos_por_gestacao bag
+    LEFT JOIN infos_gestante_atendimento_individual_recente ig
+        ON bag.chave_gestante = ig.chave_gestante
+    LEFT JOIN impulso_previne_dados_nominais.eventos_pre_natal odonto 
+        ON bag.chave_gestante = odonto.chave_gestante
+        AND odonto.tipo_registro = 'atendimento_odontologico'
+    LEFT JOIN impulso_previne_dados_nominais.eventos_pre_natal sifilis 
+        ON bag.chave_gestante = sifilis.chave_gestante
+        AND sifilis.tipo_registro IN ('teste_rapido_exame_sifilis','exame_sifilis_avaliado')
+    LEFT JOIN impulso_previne_dados_nominais.eventos_pre_natal hiv 
+        ON bag.chave_gestante = hiv.chave_gestante
+        AND hiv.tipo_registro IN ('teste_rapido_exame_hiv','exame_hiv_avaliado')
+    LEFT JOIN impulso_previne_dados_nominais.eventos_pre_natal parto 
+        ON bag.chave_gestante = parto.chave_gestante
+        AND parto.tipo_registro = 'registro_de_parto'
+    LEFT JOIN impulso_previne_dados_nominais.eventos_pre_natal aborto 
+        ON bag.chave_gestante = aborto.chave_gestante
+        AND aborto.tipo_registro = 'registro_de_aborto'
+    GROUP BY 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25 
+)
+, aux AS (
+SELECT 
+    *, 
+    CASE
+        WHEN exame_sifilis_realizado IS TRUE  AND exame_hiv_realizado IS TRUE 
+            THEN TRUE
+        ELSE FALSE
+    END AS exame_sifilis_hiv_realizado,
     now() AS atualizacao_data,
-    now() AS criacao_data
-   FROM base_final_gestacoes
-  WHERE base_final_gestacoes.gestacao_data_dpp >=
-        CASE
-            WHEN date_part('month'::text, CURRENT_DATE) >= 1::double precision AND date_part('month'::text, CURRENT_DATE) <= 4::double precision THEN concat(date_part('year'::text, (CURRENT_DATE - '365 days'::interval)::date), '-09-01')
-            WHEN date_part('month'::text, CURRENT_DATE) >= 5::double precision AND date_part('month'::text, CURRENT_DATE) <= 8::double precision THEN concat(date_part('year'::text, CURRENT_DATE), '-01-01')
-            WHEN date_part('month'::text, CURRENT_DATE) >= 9::double precision AND date_part('month'::text, CURRENT_DATE) <= 12::double precision THEN concat(date_part('year'::text, CURRENT_DATE), '-05-01')
-            ELSE NULL::text
-        END::date OR base_final_gestacoes.consulta_prenatal_ultima_data >=
-        CASE
-            WHEN date_part('month'::text, CURRENT_DATE) >= 1::double precision AND date_part('month'::text, CURRENT_DATE) <= 4::double precision THEN concat(date_part('year'::text, (CURRENT_DATE - '365 days'::interval)::date), '-09-01')
-            WHEN date_part('month'::text, CURRENT_DATE) >= 5::double precision AND date_part('month'::text, CURRENT_DATE) <= 8::double precision THEN concat(date_part('year'::text, CURRENT_DATE), '-01-01')
-            WHEN date_part('month'::text, CURRENT_DATE) >= 9::double precision AND date_part('month'::text, CURRENT_DATE) <= 12::double precision THEN concat(date_part('year'::text, CURRENT_DATE), '-05-01')
-            ELSE NULL::text
-        END::date
+    now() AS criacao_data 
+FROM base_final_gestacoes
+WHERE 
+    gestacao_data_dpp >= (CASE
+                                WHEN date_part('month', CURRENT_DATE) >= 1::double precision AND date_part('month', CURRENT_DATE) <= 4::double precision THEN concat(date_part('year', (CURRENT_DATE - '365 days'::interval)::date), '-09-01')
+                                WHEN date_part('month', CURRENT_DATE) >= 5::double precision AND date_part('month', CURRENT_DATE) <= 8::double precision THEN concat(date_part('year', CURRENT_DATE), '-01-01')
+                                WHEN date_part('month', CURRENT_DATE) >= 9::double precision AND date_part('month', CURRENT_DATE) <= 12::double precision THEN concat(date_part('year', CURRENT_DATE), '-05-01')
+                                ELSE NULL::text
+                            END::date)
+    OR consulta_prenatal_ultima_data >= CASE
+                                            WHEN date_part('month', CURRENT_DATE) >= 1::double precision AND date_part('month', CURRENT_DATE) <= 4::double precision THEN concat(date_part('year', (CURRENT_DATE - '365 days'::interval)::date), '-09-01')
+                                            WHEN date_part('month', CURRENT_DATE) >= 5::double precision AND date_part('month', CURRENT_DATE) <= 8::double precision THEN concat(date_part('year', CURRENT_DATE), '-01-01')
+                                            WHEN date_part('month', CURRENT_DATE) >= 9::double precision AND date_part('month', CURRENT_DATE) <= 12::double precision THEN concat(date_part('year', CURRENT_DATE), '-05-01')
+                                            ELSE NULL::text
+                                        END::date
+)
+SELECT *
+FROM aux
+where equipe_ine not in ('0000071722', '0000071730', '0001511912', '0001846892', '0001847236', '0002275872')
 WITH DATA;
 
 -- View indexes:

--- a/Scripts/lista_nominal_indicadores/novo_codigo_lista_gestantes
+++ b/Scripts/lista_nominal_indicadores/novo_codigo_lista_gestantes
@@ -31,28 +31,28 @@ WITH atendimentos_pre_natal AS (
 			uns.no_unidade_saude AS estabelecimento_atendimento,
 			eq.nu_ine AS ine_equipe_atendimento,
 			eq.no_equipe AS equipe_atendimento
-	    FROM esus_3169356_tresmarias_mg_20230314.tb_fat_atendimento_individual tfai
-	    JOIN esus_3169356_tresmarias_mg_20230314.tb_dim_cbo tdcbo 
+	    FROM tb_fat_atendimento_individual tfai
+	    JOIN tb_dim_cbo tdcbo 
 	    	ON tdcbo.co_seq_dim_cbo = tfai.co_dim_cbo_1
-	    JOIN esus_3169356_tresmarias_mg_20230314.tb_dim_tempo tdt 
+	    JOIN tb_dim_tempo tdt 
 	    	ON tfai.co_dim_tempo = tdt.co_seq_dim_tempo
-	    JOIN esus_3169356_tresmarias_mg_20230314.tb_dim_tempo tdtdum 
+	    JOIN tb_dim_tempo tdtdum 
 	    	ON tfai.co_dim_tempo_dum = tdtdum.co_seq_dim_tempo
-	    JOIN esus_3169356_tresmarias_mg_20230314.tb_fat_atd_ind_problemas tfaip 
+	    JOIN tb_fat_atd_ind_problemas tfaip 
 	    	ON tfai.co_seq_fat_atd_ind = tfaip.co_fat_atd_ind
-	    LEFT JOIN esus_3169356_tresmarias_mg_20230314.tb_dim_profissional tdprof
+	    LEFT JOIN tb_dim_profissional tdprof
 			ON tdprof.co_seq_dim_profissional = tfai.co_dim_profissional_1
-		LEFT JOIN esus_3169356_tresmarias_mg_20230314.tb_dim_equipe eq
+		LEFT JOIN tb_dim_equipe eq
 			ON eq.co_seq_dim_equipe = tfai.co_dim_equipe_1
-		LEFT JOIN esus_3169356_tresmarias_mg_20230314.tb_dim_unidade_saude uns 
+		LEFT JOIN tb_dim_unidade_saude uns 
 			ON uns.co_seq_dim_unidade_saude = tfai.co_dim_unidade_saude_1
-	    JOIN esus_3169356_tresmarias_mg_20230314.tb_fat_cidadao_pec tfcp 
+	    JOIN tb_fat_cidadao_pec tfcp 
 	    	ON tfcp.co_seq_fat_cidadao_pec = tfai.co_fat_cidadao_pec
-	    JOIN esus_3169356_tresmarias_mg_20230314.tb_dim_tempo tempocidadaopec 
+	    JOIN tb_dim_tempo tempocidadaopec 
 	    	ON tempocidadaopec.co_seq_dim_tempo = tfcp.co_dim_tempo_nascimento
-	    LEFT JOIN esus_3169356_tresmarias_mg_20230314.tb_dim_cid tdcid 
+	    LEFT JOIN tb_dim_cid tdcid 
 	    	ON tdcid.co_seq_dim_cid = tfaip.co_dim_cid
-	    LEFT JOIN esus_3169356_tresmarias_mg_20230314.tb_dim_ciap tdciap 
+	    LEFT JOIN tb_dim_ciap tdciap 
 	    	ON tdciap.co_seq_dim_ciap = tfaip.co_dim_ciap
 	   WHERE (tdcbo.nu_cbo::text ~~ ANY (ARRAY['2231%'::text, '2235%'::text, '2251%'::text, '2252%'::text, '2253%'::text])) 
 	   		AND ((tdciap.nu_ciap::text = ANY (ARRAY['ABP001'::text, 'W03'::text, 'W05'::text, 'W29'::text, 'W71'::text, 'W78'::text, 'W79'::text, 'W80'::text, 'W81'::text, 'W84'::text, 'W85'::text])) 
@@ -94,22 +94,22 @@ WITH atendimentos_pre_natal AS (
 		uns.no_unidade_saude AS estabelecimento_atendimento,
 		eq.nu_ine AS ine_equipe_atendimento,
 		eq.no_equipe AS equipe_atendimento
-	FROM esus_3169356_tresmarias_mg_20230314.tb_fat_atendimento_individual tfaiparto
-	JOIN esus_3169356_tresmarias_mg_20230314.tb_fat_atd_ind_problemas tfaipparto 
+	FROM tb_fat_atendimento_individual tfaiparto
+	JOIN tb_fat_atd_ind_problemas tfaipparto 
 		ON tfaiparto.co_seq_fat_atd_ind = tfaipparto.co_fat_atd_ind
-	JOIN esus_3169356_tresmarias_mg_20230314.tb_dim_tempo tdtempoparto 
+	JOIN tb_dim_tempo tdtempoparto 
 		ON tdtempoparto.co_seq_dim_tempo = tfaiparto.co_dim_tempo
-	LEFT JOIN esus_3169356_tresmarias_mg_20230314.tb_dim_profissional tdprof
+	LEFT JOIN tb_dim_profissional tdprof
 		ON tdprof.co_seq_dim_profissional = tfaiparto.co_dim_profissional_1
-	LEFT JOIN esus_3169356_tresmarias_mg_20230314.tb_dim_equipe eq
+	LEFT JOIN tb_dim_equipe eq
 		ON eq.co_seq_dim_equipe = tfaiparto.co_dim_equipe_1
-	LEFT JOIN esus_3169356_tresmarias_mg_20230314.tb_dim_unidade_saude uns 
+	LEFT JOIN tb_dim_unidade_saude uns 
 		ON uns.co_seq_dim_unidade_saude = tfaiparto.co_dim_unidade_saude_1
-	LEFT JOIN esus_3169356_tresmarias_mg_20230314.tb_dim_cid tdcidparto 
+	LEFT JOIN tb_dim_cid tdcidparto 
 		ON tdcidparto.co_seq_dim_cid = tfaipparto.co_dim_cid
-	LEFT JOIN esus_3169356_tresmarias_mg_20230314.tb_dim_ciap tdciapparto 
+	LEFT JOIN tb_dim_ciap tdciapparto 
 		ON tdciapparto.co_seq_dim_ciap = tfaipparto.co_dim_ciap
-	LEFT JOIN esus_3169356_tresmarias_mg_20230314.tb_fat_cidadao_pec tfcp 
+	LEFT JOIN tb_fat_cidadao_pec tfcp 
 		ON tfaiparto.co_fat_cidadao_pec = tfcp.co_seq_fat_cidadao_pec
 	JOIN gestantes_unicas gu 
 		ON gu.chave_gestante = tfcp.no_cidadao||tfcp.co_dim_tempo_nascimento
@@ -137,22 +137,22 @@ WITH atendimentos_pre_natal AS (
 		uns.no_unidade_saude AS estabelecimento_atendimento,
 		eq.nu_ine AS ine_equipe_atendimento,
 		eq.no_equipe AS equipe_atendimento
-	FROM esus_3169356_tresmarias_mg_20230314.tb_fat_atendimento_individual tfaiaborto
-	JOIN esus_3169356_tresmarias_mg_20230314.tb_fat_atd_ind_problemas tfaipaborto 
+	FROM tb_fat_atendimento_individual tfaiaborto
+	JOIN tb_fat_atd_ind_problemas tfaipaborto 
 		ON tfaiaborto.co_seq_fat_atd_ind = tfaipaborto.co_fat_atd_ind
-	JOIN esus_3169356_tresmarias_mg_20230314.tb_dim_tempo tdtempoaborto 
+	JOIN tb_dim_tempo tdtempoaborto 
 		ON tdtempoaborto.co_seq_dim_tempo = tfaiaborto.co_dim_tempo
-	LEFT JOIN esus_3169356_tresmarias_mg_20230314.tb_dim_profissional tdprof
+	LEFT JOIN tb_dim_profissional tdprof
 		ON tdprof.co_seq_dim_profissional = tfaiaborto.co_dim_profissional_1
-	LEFT JOIN esus_3169356_tresmarias_mg_20230314.tb_dim_equipe eq
+	LEFT JOIN tb_dim_equipe eq
 		ON eq.co_seq_dim_equipe = tfaiaborto.co_dim_equipe_1
-	LEFT JOIN esus_3169356_tresmarias_mg_20230314.tb_dim_unidade_saude uns 
+	LEFT JOIN tb_dim_unidade_saude uns 
 		ON uns.co_seq_dim_unidade_saude = tfaiaborto.co_dim_unidade_saude_1
-	LEFT JOIN esus_3169356_tresmarias_mg_20230314.tb_dim_cid tdcidaborto 
+	LEFT JOIN tb_dim_cid tdcidaborto 
 		ON tdcidaborto.co_seq_dim_cid = tfaipaborto.co_dim_cid
-	LEFT JOIN esus_3169356_tresmarias_mg_20230314.tb_dim_ciap tdciapaborto 
+	LEFT JOIN tb_dim_ciap tdciapaborto 
 		ON tdciapaborto.co_seq_dim_ciap = tfaipaborto.co_dim_ciap
-	LEFT JOIN esus_3169356_tresmarias_mg_20230314.tb_fat_cidadao_pec tfcp 
+	LEFT JOIN tb_fat_cidadao_pec tfcp 
 		ON tfaiaborto.co_fat_cidadao_pec = tfcp.co_seq_fat_cidadao_pec
 	JOIN gestantes_unicas gu 
 		ON gu.chave_gestante = tfcp.no_cidadao||tfcp.co_dim_tempo_nascimento
@@ -181,20 +181,20 @@ WITH atendimentos_pre_natal AS (
 		uns.no_unidade_saude AS estabelecimento_atendimento,
 		eq.nu_ine AS ine_equipe_atendimento,
 		eq.no_equipe AS equipe_atendimento
-	FROM esus_3169356_tresmarias_mg_20230314.tb_fat_atendimento_odonto tfaodont
-	JOIN esus_3169356_tresmarias_mg_20230314.tb_fat_cidadao_pec tfcp
+	FROM tb_fat_atendimento_odonto tfaodont
+	JOIN tb_fat_cidadao_pec tfcp
 		ON tfcp.co_seq_fat_cidadao_pec = tfaodont.co_fat_cidadao_pec
 	JOIN gestantes_unicas gu 
 		ON gu.chave_gestante = tfcp.no_cidadao||tfcp.co_dim_tempo_nascimento
-	LEFT JOIN esus_3169356_tresmarias_mg_20230314.tb_dim_profissional tdprof
+	LEFT JOIN tb_dim_profissional tdprof
 		ON tdprof.co_seq_dim_profissional = tfaodont.co_dim_profissional_1
-	LEFT JOIN esus_3169356_tresmarias_mg_20230314.tb_dim_equipe eq
+	LEFT JOIN tb_dim_equipe eq
 		ON eq.co_seq_dim_equipe = tfaodont.co_dim_equipe_1
-	LEFT JOIN esus_3169356_tresmarias_mg_20230314.tb_dim_unidade_saude uns 
+	LEFT JOIN tb_dim_unidade_saude uns 
 		ON uns.co_seq_dim_unidade_saude = tfaodont.co_dim_unidade_saude_1
-	JOIN esus_3169356_tresmarias_mg_20230314.tb_dim_cbo otdcbo 
+	JOIN tb_dim_cbo otdcbo 
 		ON otdcbo.co_seq_dim_cbo = tfaodont.co_dim_cbo_1
-	JOIN esus_3169356_tresmarias_mg_20230314.tb_dim_tempo otdtempo 
+	JOIN tb_dim_tempo otdtempo 
 		ON otdtempo.co_seq_dim_tempo = tfaodont.co_dim_tempo
 	WHERE otdcbo.nu_cbo::text ~~ '2232%'::text 
 	    AND otdtempo.dt_registro >= (( 
@@ -227,22 +227,22 @@ WITH atendimentos_pre_natal AS (
 		uns.no_unidade_saude AS estabelecimento_atendimento,
 		eq.nu_ine AS ine_equipe_atendimento,
 		eq.no_equipe AS equipe_atendimento
-	FROM esus_3169356_tresmarias_mg_20230314.tb_fat_proced_atend_proced tfpap
-	JOIN esus_3169356_tresmarias_mg_20230314.tb_fat_cidadao_pec tfcp
+	FROM tb_fat_proced_atend_proced tfpap
+	JOIN tb_fat_cidadao_pec tfcp
 		ON tfcp.co_seq_fat_cidadao_pec = tfpap.co_fat_cidadao_pec
 	JOIN gestantes_unicas gu 
 		ON gu.chave_gestante = tfcp.no_cidadao||tfcp.co_dim_tempo_nascimento
-	JOIN esus_3169356_tresmarias_mg_20230314.tb_dim_procedimento tdp 
+	JOIN tb_dim_procedimento tdp 
 		ON tdp.co_seq_dim_procedimento = tfpap.co_dim_procedimento
-	LEFT JOIN esus_3169356_tresmarias_mg_20230314.tb_dim_profissional tdprof
+	LEFT JOIN tb_dim_profissional tdprof
 		ON tdprof.co_seq_dim_profissional = tfpap.co_dim_profissional
-	LEFT JOIN esus_3169356_tresmarias_mg_20230314.tb_dim_equipe eq
+	LEFT JOIN tb_dim_equipe eq
 		ON eq.co_seq_dim_equipe = tfpap.co_dim_equipe
-	LEFT JOIN esus_3169356_tresmarias_mg_20230314.tb_dim_unidade_saude uns 
+	LEFT JOIN tb_dim_unidade_saude uns 
 		ON uns.co_seq_dim_unidade_saude = tfpap.co_dim_unidade_saude
-	JOIN esus_3169356_tresmarias_mg_20230314.tb_dim_cbo tdcbo 
+	JOIN tb_dim_cbo tdcbo 
 		ON tdcbo.co_seq_dim_cbo = tfpap.co_dim_cbo
-	JOIN esus_3169356_tresmarias_mg_20230314.tb_dim_tempo tdtempo 
+	JOIN tb_dim_tempo tdtempo 
 		ON tdtempo.co_seq_dim_tempo = tfpap.co_dim_tempo
 	WHERE  (tdcbo.nu_cbo::text ~~ ANY (ARRAY['2251%'::text, '2252%'::text, '2253%'::text, '2231%'::text, '2235%'::text, '3222%'::text]))
 		AND (tdp.co_proced::text = ANY (ARRAY['0214010058'::text, '0214010040'::text, 'ABPG024'::text]))
@@ -275,22 +275,22 @@ UNION ALL
 		uns.no_unidade_saude AS estabelecimento_atendimento,
 		eq.nu_ine AS ine_equipe_atendimento,
 		eq.no_equipe AS equipe_atendimento
-	FROM esus_3169356_tresmarias_mg_20230314.tb_fat_atd_ind_procedimentos tfaip
-	JOIN esus_3169356_tresmarias_mg_20230314.tb_fat_cidadao_pec tfcp
+	FROM tb_fat_atd_ind_procedimentos tfaip
+	JOIN tb_fat_cidadao_pec tfcp
 		ON tfcp.co_seq_fat_cidadao_pec = tfaip.co_fat_cidadao_pec
 	JOIN gestantes_unicas gu 
 		ON gu.chave_gestante = tfcp.no_cidadao||tfcp.co_dim_tempo_nascimento
-	JOIN esus_3169356_tresmarias_mg_20230314.tb_dim_procedimento tdp 
+	JOIN tb_dim_procedimento tdp 
 		ON tdp.co_seq_dim_procedimento = tfaip.co_dim_procedimento_avaliado
-	LEFT JOIN esus_3169356_tresmarias_mg_20230314.tb_dim_profissional tdprof
+	LEFT JOIN tb_dim_profissional tdprof
 		ON tdprof.co_seq_dim_profissional = tfaip.co_dim_profissional_1
-	LEFT JOIN esus_3169356_tresmarias_mg_20230314.tb_dim_equipe eq
+	LEFT JOIN tb_dim_equipe eq
 		ON eq.co_seq_dim_equipe = tfaip.co_dim_equipe_1
-	LEFT JOIN esus_3169356_tresmarias_mg_20230314.tb_dim_unidade_saude uns 
+	LEFT JOIN tb_dim_unidade_saude uns 
 		ON uns.co_seq_dim_unidade_saude = tfaip.co_dim_unidade_saude_1
-	JOIN esus_3169356_tresmarias_mg_20230314.tb_dim_cbo tdcbo 
+	JOIN tb_dim_cbo tdcbo 
 		ON tdcbo.co_seq_dim_cbo = tfaip.co_dim_cbo_1
-	JOIN esus_3169356_tresmarias_mg_20230314.tb_dim_tempo tdtempo 
+	JOIN tb_dim_tempo tdtempo 
 		ON tdtempo.co_seq_dim_tempo = tfaip.co_dim_tempo
 	WHERE  (tdcbo.nu_cbo::text ~~ ANY (ARRAY['2251%'::text, '2252%'::text, '2253%'::text, '2231%'::text, '2235%'::text, '3222%'::text])) 
 		AND (tdp.co_proced::text = ANY (ARRAY['0202030300'::text, 'ABEX018'::text]))
@@ -324,22 +324,22 @@ UNION ALL
 		uns.no_unidade_saude AS estabelecimento_atendimento,
 		eq.nu_ine AS ine_equipe_atendimento,
 		eq.no_equipe AS equipe_atendimento
-	FROM esus_3169356_tresmarias_mg_20230314.tb_fat_proced_atend_proced tfpap
-	JOIN esus_3169356_tresmarias_mg_20230314.tb_fat_cidadao_pec tfcp
+	FROM tb_fat_proced_atend_proced tfpap
+	JOIN tb_fat_cidadao_pec tfcp
 		ON tfcp.co_seq_fat_cidadao_pec = tfpap.co_fat_cidadao_pec
 	JOIN gestantes_unicas gu 
 		ON gu.chave_gestante = tfcp.no_cidadao::text||tfcp.co_dim_tempo_nascimento
-	JOIN esus_3169356_tresmarias_mg_20230314.tb_dim_procedimento tdp 
+	JOIN tb_dim_procedimento tdp 
 		ON tdp.co_seq_dim_procedimento = tfpap.co_dim_procedimento
-	LEFT JOIN esus_3169356_tresmarias_mg_20230314.tb_dim_profissional tdprof
+	LEFT JOIN tb_dim_profissional tdprof
 		ON tdprof.co_seq_dim_profissional = tfpap.co_dim_profissional
-	LEFT JOIN esus_3169356_tresmarias_mg_20230314.tb_dim_equipe eq
+	LEFT JOIN tb_dim_equipe eq
 		ON eq.co_seq_dim_equipe = tfpap.co_dim_equipe
-	LEFT JOIN esus_3169356_tresmarias_mg_20230314.tb_dim_unidade_saude uns 
+	LEFT JOIN tb_dim_unidade_saude uns 
 		ON uns.co_seq_dim_unidade_saude = tfpap.co_dim_unidade_saude
-	JOIN esus_3169356_tresmarias_mg_20230314.tb_dim_cbo tdcbo 
+	JOIN tb_dim_cbo tdcbo 
 		ON tdcbo.co_seq_dim_cbo = tfpap.co_dim_cbo
-	JOIN esus_3169356_tresmarias_mg_20230314.tb_dim_tempo tdtempo 
+	JOIN tb_dim_tempo tdtempo 
 		ON tdtempo.co_seq_dim_tempo = tfpap.co_dim_tempo
 	WHERE (tdcbo.nu_cbo::text ~~ ANY (ARRAY['2251%'::text, '2252%'::text, '2253%'::text, '2231%'::text, '2235%'::text, '3222%'::text])) 
 		AND (tdp.co_proced::text = ANY (ARRAY['0214010074'::text, '0214010082'::text, 'ABPG026'::text]))
@@ -372,22 +372,22 @@ UNION ALL
 		uns.no_unidade_saude AS estabelecimento_atendimento,
 		eq.nu_ine AS ine_equipe_atendimento,
 		eq.no_equipe AS equipe_atendimento
-	FROM esus_3169356_tresmarias_mg_20230314.tb_fat_atd_ind_procedimentos tfaip
-	JOIN esus_3169356_tresmarias_mg_20230314.tb_fat_cidadao_pec tfcp
+	FROM tb_fat_atd_ind_procedimentos tfaip
+	JOIN tb_fat_cidadao_pec tfcp
 		ON tfcp.co_seq_fat_cidadao_pec = tfaip.co_fat_cidadao_pec
 	JOIN gestantes_unicas gu 
 		ON gu.chave_gestante = tfcp.no_cidadao::text||tfcp.co_dim_tempo_nascimento
-	JOIN esus_3169356_tresmarias_mg_20230314.tb_dim_procedimento tdp 
+	JOIN tb_dim_procedimento tdp 
 		ON tdp.co_seq_dim_procedimento = tfaip.co_dim_procedimento_avaliado
-	LEFT JOIN esus_3169356_tresmarias_mg_20230314.tb_dim_profissional tdprof
+	LEFT JOIN tb_dim_profissional tdprof
 		ON tdprof.co_seq_dim_profissional = tfaip.co_dim_profissional_1	
-	LEFT JOIN esus_3169356_tresmarias_mg_20230314.tb_dim_equipe eq
+	LEFT JOIN tb_dim_equipe eq
 		ON eq.co_seq_dim_equipe = tfaip.co_dim_equipe_1
-	LEFT JOIN esus_3169356_tresmarias_mg_20230314.tb_dim_unidade_saude uns 
+	LEFT JOIN tb_dim_unidade_saude uns 
 		ON uns.co_seq_dim_unidade_saude = tfaip.co_dim_unidade_saude_1
-	JOIN esus_3169356_tresmarias_mg_20230314.tb_dim_cbo tdcbo 
+	JOIN tb_dim_cbo tdcbo 
 		ON tdcbo.co_seq_dim_cbo = tfaip.co_dim_cbo_1
-	JOIN esus_3169356_tresmarias_mg_20230314.tb_dim_tempo tdtempo 
+	JOIN tb_dim_tempo tdtempo 
 		ON tdtempo.co_seq_dim_tempo = tfaip.co_dim_tempo
 	WHERE (tdcbo.nu_cbo::text ~~ ANY (ARRAY['2251%'::text, '2252%'::text, '2253%'::text, '2231%'::text, '2235%'::text, '3222%'::text])) 
 		AND (tdp.co_proced::text = ANY (ARRAY['0202031110'::text, '0202031179'::text, 'ABEX019'::text]))
@@ -426,18 +426,18 @@ UNION ALL
 			eq.no_equipe AS equipe_cad_individual,
 			acs.no_profissional AS acs_cad_individual,
 			row_number() OVER (PARTITION BY gu.chave_gestante ORDER BY tdt.dt_registro DESC) = 1 AS ultimo_cadastro_individual
-		FROM esus_3169356_tresmarias_mg_20230314.tb_fat_cad_individual tfci
-		JOIN esus_3169356_tresmarias_mg_20230314.tb_fat_cidadao_pec tfcpec
+		FROM tb_fat_cad_individual tfci
+		JOIN tb_fat_cidadao_pec tfcpec
 			ON tfcpec.co_seq_fat_cidadao_pec = tfci.co_fat_cidadao_pec
 		JOIN gestantes_unicas gu 
 			ON gu.chave_gestante = tfcpec.no_cidadao::text||tfcpec.co_dim_tempo_nascimento
-		LEFT JOIN esus_3169356_tresmarias_mg_20230314.tb_dim_tempo tdt 
+		LEFT JOIN tb_dim_tempo tdt 
 			ON tdt.co_seq_dim_tempo = tfci.co_dim_tempo
-		LEFT JOIN esus_3169356_tresmarias_mg_20230314.tb_dim_equipe eq
+		LEFT JOIN tb_dim_equipe eq
 			ON eq.co_seq_dim_equipe = tfci.co_dim_equipe
-		LEFT JOIN esus_3169356_tresmarias_mg_20230314.tb_dim_profissional acs
+		LEFT JOIN tb_dim_profissional acs
 			ON acs.co_seq_dim_profissional = tfci.co_dim_profissional
-		LEFT JOIN esus_3169356_tresmarias_mg_20230314.tb_dim_unidade_saude uns
+		LEFT JOIN tb_dim_unidade_saude uns
 			ON uns.co_seq_dim_unidade_saude = tfci.co_dim_unidade_saude  
 		)
 	SELECT * FROM base WHERE ultimo_cadastro_individual IS TRUE
@@ -451,14 +451,14 @@ UNION ALL
 			tdt.dt_registro AS data_visita_acs,
 			acs.no_profissional AS acs_visita_domiciliar,
 			row_number() OVER (PARTITION BY gu.chave_gestante ORDER BY tdt.dt_registro DESC) = 1 AS ultima_visita_domiciliar
-		FROM esus_3169356_tresmarias_mg_20230314.tb_fat_visita_domiciliar visitadomiciliar
-		JOIN esus_3169356_tresmarias_mg_20230314.tb_fat_cidadao_pec tfcpec
+		FROM tb_fat_visita_domiciliar visitadomiciliar
+		JOIN tb_fat_cidadao_pec tfcpec
 			ON tfcpec.co_seq_fat_cidadao_pec = visitadomiciliar.co_fat_cidadao_pec 
 		JOIN gestantes_unicas gu 
 			ON gu.chave_gestante = tfcpec.no_cidadao::text||tfcpec.co_dim_tempo_nascimento
-		LEFT JOIN esus_3169356_tresmarias_mg_20230314.tb_dim_profissional acs
+		LEFT JOIN tb_dim_profissional acs
 			ON acs.co_seq_dim_profissional = visitadomiciliar.co_dim_profissional
-		LEFT JOIN esus_3169356_tresmarias_mg_20230314.tb_dim_tempo tdt 
+		LEFT JOIN tb_dim_tempo tdt 
 			ON tdt.co_seq_dim_tempo = visitadomiciliar.co_dim_tempo
 		)
 	SELECT * FROM base WHERE ultima_visita_domiciliar IS TRUE 
@@ -477,20 +477,20 @@ UNION ALL
 			acs.no_profissional AS acs_cad_dom_familia,
 			NULLIF(concat(cadomiciliar.no_logradouro, ', ', cadomiciliar.nu_num_logradouro), ', '::text) AS gestante_endereco,
 			row_number() OVER (PARTITION BY gu.chave_gestante ORDER BY tdt.dt_registro DESC) = 1  AS ultimo_cadastro_domiciliar_familia
-		FROM esus_3169356_tresmarias_mg_20230314.tb_fat_cad_dom_familia caddomiciliarfamilia
-		JOIN esus_3169356_tresmarias_mg_20230314.tb_fat_cad_domiciliar cadomiciliar 
+		FROM tb_fat_cad_dom_familia caddomiciliarfamilia
+		JOIN tb_fat_cad_domiciliar cadomiciliar 
 			ON cadomiciliar.co_seq_fat_cad_domiciliar = caddomiciliarfamilia.co_fat_cad_domiciliar
-		JOIN esus_3169356_tresmarias_mg_20230314.tb_fat_cidadao_pec tfcpec
+		JOIN tb_fat_cidadao_pec tfcpec
 			ON tfcpec.co_seq_fat_cidadao_pec = caddomiciliarfamilia.co_fat_cidadao_pec 
 		JOIN gestantes_unicas gu 
 			ON gu.chave_gestante = tfcpec.no_cidadao::text||tfcpec.co_dim_tempo_nascimento
-		LEFT JOIN esus_3169356_tresmarias_mg_20230314.tb_dim_tempo tdt 
+		LEFT JOIN tb_dim_tempo tdt 
 			ON tdt.co_seq_dim_tempo = caddomiciliarfamilia.co_dim_tempo
-		LEFT JOIN esus_3169356_tresmarias_mg_20230314.tb_dim_equipe eq
+		LEFT JOIN tb_dim_equipe eq
 			ON eq.co_seq_dim_equipe = caddomiciliarfamilia.co_dim_equipe
-		LEFT JOIN esus_3169356_tresmarias_mg_20230314.tb_dim_profissional acs
+		LEFT JOIN tb_dim_profissional acs
 			ON acs.co_seq_dim_profissional = caddomiciliarfamilia.co_dim_profissional
-		LEFT JOIN esus_3169356_tresmarias_mg_20230314.tb_dim_unidade_saude uns
+		LEFT JOIN tb_dim_unidade_saude uns
 			ON uns.co_seq_dim_unidade_saude = caddomiciliarfamilia.co_dim_unidade_saude  		
 		)
 	SELECT * FROM base WHERE ultimo_cadastro_domiciliar_familia IS TRUE
@@ -549,42 +549,43 @@ UNION ALL
 				b.profissional_atendimento,
 				-- Se a data de DUM é inválida ('3000-12-31'), procuramos o registro de idade_gestacional (casos de ficha CDS)
 				CASE
-					WHEN b.data_dum <> '3000-12-31'::date
-						THEN b.data_dum
-					WHEN b.idade_gestacional_atendimento IS NOT NULL 
-						THEN (b.data_registro - '7 days'::interval * b.idade_gestacional_atendimento::double precision)::date
-					ELSE NULL::date
-				END AS data_dum_atendimento,
-				CASE
-					WHEN b.data_dum <> '3000-12-31'::date
-						THEN (b.data_dum + '294 days'::INTERVAL)::date
-					WHEN b.idade_gestacional_atendimento IS NOT NULL 
-						THEN (b.data_registro - '7 days'::interval * b.idade_gestacional_atendimento::double precision + '294 days'::INTERVAL)::date
-					ELSE NULL::date
-				END AS data_dpp_atendimento,
-				CASE
-					WHEN b.data_dum <> '3000-12-31'::date
-						THEN (CURRENT_DATE - b.data_dum) / 7
-					WHEN b.idade_gestacional_atendimento IS NOT NULL 
-						THEN (CURRENT_DATE - (b.data_registro - '7 days'::interval * b.idade_gestacional_atendimento::double precision)::date) / 7
-					ELSE NULL::integer
-				END AS gestante_idade_gestacional,
-				CASE 
-					WHEN b.idade_gestacional_atendimento IS NOT NULL
-						THEN b.idade_gestacional_atendimento
-					WHEN b.data_dum <> '3000-12-31'::date
-						THEN (b.data_registro - b.data_dum) / 7
-					ELSE NULL::integer
-				END AS gestante_idade_gestacional_atendimento
+                    WHEN COALESCE(b.data_dum,'3000-12-31'::date) <> '3000-12-31'::date
+                        THEN b.data_dum
+                    WHEN b.idade_gestacional_atendimento IS NOT NULL 
+                        THEN (b.data_registro - '7 days'::interval * b.idade_gestacional_atendimento::double precision)::date
+                    ELSE NULL::date
+                END AS data_dum_atendimento,
+                CASE
+                    WHEN COALESCE(b.data_dum,'3000-12-31'::date) <> '3000-12-31'::date
+                        THEN (b.data_dum + '294 days'::INTERVAL)::date
+                    WHEN b.idade_gestacional_atendimento IS NOT NULL 
+                        THEN (b.data_registro - '7 days'::interval * b.idade_gestacional_atendimento::double precision + '294 days'::INTERVAL)::date
+                    ELSE NULL::date
+                END AS data_dpp_atendimento,
+                CASE
+                    WHEN COALESCE(b.data_dum,'3000-12-31'::date) <> '3000-12-31'::date
+                        THEN (CURRENT_DATE - b.data_dum) / 7
+                    WHEN b.idade_gestacional_atendimento IS NOT NULL 
+                        THEN (CURRENT_DATE - (b.data_registro - '7 days'::interval * b.idade_gestacional_atendimento::double precision)::date) / 7
+                    ELSE NULL::integer
+                END AS gestante_idade_gestacional,
+                CASE 
+                    WHEN COALESCE(b.data_dum,'3000-12-31'::date) <> '3000-12-31'::date
+                        THEN (b.data_registro - b.data_dum) / 7
+                    WHEN b.idade_gestacional_atendimento IS NOT NULL
+                        THEN b.idade_gestacional_atendimento
+                    ELSE NULL::integer
+                END AS gestante_idade_gestacional_atendimento
 			FROM base_final_registros b
 			WHERE b.tipo_registro = 'consulta_pre_natal'
-			)
+			)		
 		SELECT 
 			b.*,
 			-- Pelas regras do SISAB a data de DUM considerada na gestação é a primeira data com registro válido 
 			(array_agg(b.data_atendimento) FILTER (WHERE b.data_dum_atendimento IS NOT NULL) OVER (PARTITION BY b.chave_gestante ORDER BY b.id_registro ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING))[1] AS primeira_data_consulta_pre_natal_com_DUM,
 			(array_agg(b.data_dum_atendimento) FILTER (WHERE b.data_dum_atendimento IS NOT NULL) OVER (PARTITION BY b.chave_gestante ORDER BY b.id_registro ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING))[1] AS primeira_data_dum_valida
 		FROM base b
+		--select * from base_atendimentos_pre_natal
 )
 , validacao_dum AS (
 -- Análise da data de DUM que é a base para definição do fim e início das gestacoes
@@ -706,6 +707,7 @@ UNION ALL
 		(array_agg(apn.data_dum_atendimento) FILTER (WHERE apn.data_dum_atendimento IS NOT NULL) OVER (PARTITION BY apn.chave_gestante ORDER BY apn.data_atendimento ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING))[1] AS data_primeira_DUM_valida,
 		(array_agg(apn.data_atendimento) FILTER (WHERE apn.data_dum_atendimento IS NOT NULL) OVER (PARTITION BY apn.chave_gestante ORDER BY apn.data_atendimento ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING))[1] AS data_atendimento_com_primeira_DUM_valida,
 		(array_agg(apn.gestante_idade_gestacional_atendimento) FILTER (WHERE apn.data_dum_atendimento IS NOT NULL) OVER (PARTITION BY apn.chave_gestante ORDER BY apn.data_atendimento ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING))[1] AS idade_gestacional_atendimento_com_primeira_DUM_valida,
+		(array_agg(apn.gestante_idade_gestacional) FILTER (WHERE apn.data_dum_atendimento IS NOT NULL) OVER (PARTITION BY apn.chave_gestante ORDER BY apn.data_atendimento ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING))[1] AS idade_gestacional_atual_com_primeira_DUM_valida,
 		cg.data_fim_primeira_gestacao,
 		cg.tipo_encerramento_primeira_gestacao,
 		cg.quant_gestacoes,
@@ -742,6 +744,7 @@ UNION ALL
 		(array_agg(apn.data_dum_atendimento) FILTER (WHERE apn.data_dum_atendimento IS NOT NULL) OVER (PARTITION BY apn.chave_gestante ORDER BY apn.data_atendimento ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING))[1] AS data_primeira_DUM_valida,
 		(array_agg(apn.data_atendimento) FILTER (WHERE apn.data_dum_atendimento IS NOT NULL) OVER (PARTITION BY apn.chave_gestante ORDER BY apn.data_atendimento ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING))[1] AS data_atendimento_com_primeira_DUM_valida,
 		(array_agg(apn.gestante_idade_gestacional_atendimento) FILTER (WHERE apn.data_dum_atendimento IS NOT NULL) OVER (PARTITION BY apn.chave_gestante ORDER BY apn.data_atendimento ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING))[1] AS idade_gestacional_atendimento_com_primeira_DUM_valida,
+		(array_agg(apn.gestante_idade_gestacional) FILTER (WHERE apn.data_dum_atendimento IS NOT NULL) OVER (PARTITION BY apn.chave_gestante ORDER BY apn.data_atendimento ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING))[1] AS idade_gestacional_atual_com_primeira_DUM_valida,
 		cg.data_fim_primeira_gestacao,
 		cg.tipo_encerramento_primeira_gestacao,
 		cg.quant_gestacoes,
@@ -814,14 +817,6 @@ SELECT * FROM base WHERE ultimo_atendimento_individual IS TRUE
 		UPPER(COALESCE(NULLIF(ig.equipe_cad_individual::text, 'SEM EQUIPE'::text), ig.equipe_atendimento::text)) AS equipe_nome,
 		UPPER(COALESCE(ig.acs_visita_domiciliar, ig.acs_cad_individual, 'SEM ACS')) AS acs_nome,
 		ig.data_ultima_visita_acs AS acs_data_ultima_visita,
-		ig.estabelecimento_cnes_atendimento,
-		ig.estabelecimento_atendimento,
-		ig.ine_equipe_atendimento,
-		ig.equipe_atendimento,
-		ig.cnes_estabelecimento_cad_individual,
-		ig.estabelecimento_cad_individual,
-		ig.ine_equipe_cad_individual,
-		ig.equipe_cad_individual,
 		bag.data_primeira_DUM_valida AS gestacao_data_dum,
 		(bag.data_primeira_DUM_valida + '294 days'::INTERVAL)::DATE AS gestacao_data_dpp,
 		(bag.data_primeira_DUM_valida + '294 days'::INTERVAL)::DATE - CURRENT_DATE AS gestacao_dpp_dias_para,
@@ -848,7 +843,7 @@ SELECT * FROM base WHERE ultimo_atendimento_individual IS TRUE
 		bag.tipo_encerramento_primeira_gestacao,
 		ig.gestante_documento_cpf,
 		ig.gestante_documento_cns,
-		MAX(bag.gestante_idade_gestacional) AS gestacao_idade_gestacional_atual,
+		bag.idade_gestacional_atual_com_primeira_DUM_valida AS gestacao_idade_gestacional_atual,
 		CONCAT(max(bag.quant_gestacoes),', ',max(bag.tipo_registro_parto),', ', max(bag.tipo_registro_aborto),', ',max(bag.registro_com_dpp_passado), ', ',max(consulta_proxima_fim_gestacao)) AS sinalizacao_erro_registro,
 		-- No caso de somente DUM inváidas, não inferimos datas de início e fim de gestação
 		CASE 
@@ -932,8 +927,9 @@ SELECT * FROM base WHERE ultimo_atendimento_individual IS TRUE
 	LEFT JOIN base_final_registros aborto 
 		ON bag.chave_gestante = aborto.chave_gestante
 		AND aborto.tipo_registro = 'registro_de_aborto'
-	GROUP BY 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32
+	GROUP BY 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25 
 )
+, aux AS (
 SELECT 
 	*, 
 	CASE
@@ -951,9 +947,13 @@ WHERE
 						 		WHEN date_part('month', CURRENT_DATE) >= 9::double precision AND date_part('month', CURRENT_DATE) <= 12::double precision THEN concat(date_part('year', CURRENT_DATE), '-05-01')
 						 		ELSE NULL::text
 							END::date)
-	OR consulta_prenatal_ultima_data >= (CASE
+	OR consulta_prenatal_ultima_data >= CASE
 								 			WHEN date_part('month', CURRENT_DATE) >= 1::double precision AND date_part('month', CURRENT_DATE) <= 4::double precision THEN concat(date_part('year', (CURRENT_DATE - '365 days'::interval)::date), '-09-01')
 									 		WHEN date_part('month', CURRENT_DATE) >= 5::double precision AND date_part('month', CURRENT_DATE) <= 8::double precision THEN concat(date_part('year', CURRENT_DATE), '-01-01')
 									 		WHEN date_part('month', CURRENT_DATE) >= 9::double precision AND date_part('month', CURRENT_DATE) <= 12::double precision THEN concat(date_part('year', CURRENT_DATE), '-05-01')
 									 		ELSE NULL::text
-										END::date)
+										END::date
+)
+SELECT *
+FROM aux
+where equipe_ine not in ('0000071722', '0000071730', '0001511912', '0001846892', '0001847236', '0002275872')


### PR DESCRIPTION
**Atualizações**
- Correção da idade gestacional (IG) atual (feita em julho)
_Erro:_ regra anterior pegava a MAX IG calculada - se a gestante tinha mais de uma DUM isso poderia variar. 
_Correção:_ pega IG atual calculada de acordo com a primeira DUM válida

- Correção da regra que calcula a IG no atendimento 
_Erro:_ regra anterior tinha a seguinte ordem de condicional ->  
1. vê se tem IG preenchida no atendimento, 
2. se não tem IG preenchida:  calcula IG do atendimento de acordo com a DUM
Problema: regra não estava de acordo com a regra oficial no SISAB para contabilização do indicador de 6 consultas nas primeiras 12 semanas de gestação) 

. pegava a MAX IG calculada - se a gestante tinha mais de uma DUM isso poderia variar. 
_Correção:_ inversão das condicionais: 
1. vê se tem DUM preenchida, se sim calcula IG do atendimento de acordo com a DUM
2. se não tem DUM preenchida, procura a IG preenchida manualmente
