### PR TITLE
Cria campo de data de produção mais recente nos paineis das listas nominais

### DIFF
--- a/bd_analitico/esus-backups/impulso_previne_dados_nominais/views_materializadas/api_futuro_painel_gestantes_lista_nominal.sql
+++ b/bd_analitico/esus-backups/impulso_previne_dados_nominais/views_materializadas/api_futuro_painel_gestantes_lista_nominal.sql
@@ -8,6 +8,7 @@ AS WITH acs_info AS (
             tb.acs_cad_individual
            FROM impulso_previne_dados_nominais.eventos_pre_natal tb
         )
+, tabela_aux as ( 
  SELECT tb1.chave_gestacao AS chave_id_gestacao,
     tb1.chave_gestante AS chave_id_gestante,
     tb1.municipio_id_sus,
@@ -68,4 +69,21 @@ AS WITH acs_info AS (
    FROM impulso_previne_dados_nominais.lista_nominal_gestantes_unificada tb1
      LEFT JOIN listas_de_codigos.periodos p ON tb1.gestacao_quadrimestre = p.codigo::text
      LEFT JOIN acs_info acs ON acs.chave_gestante::text = tb1.chave_gestante::text
+) 
+, data_registro_producao AS (
+    SELECT 
+        municipio_id_sus,
+    	equipe_ine,
+        MAX(GREATEST(consulta_prenatal_ultima_data::date)) AS dt_registro_producao_mais_recente,
+        MIN(LEAST(consulta_prenatal_ultima_data::date)) AS dt_registro_producao_mais_antigo
+    FROM tabela_aux
+    GROUP BY 1, 2
+) 
+SELECT
+    tabela_aux.*,
+    drp.dt_registro_producao_mais_recente
+FROM tabela_aux
+LEFT JOIN data_registro_producao drp 
+    ON drp.municipio_id_sus = tabela_aux.municipio_id_sus
+    AND drp.equipe_ine = tabela_aux.equipe_ine
 WITH DATA;

--- a/bd_analitico/esus-backups/impulso_previne_dados_nominais/views_materializadas/painel_coordenadores_lista_nominal_gestantes.sql
+++ b/bd_analitico/esus-backups/impulso_previne_dados_nominais/views_materializadas/painel_coordenadores_lista_nominal_gestantes.sql
@@ -250,8 +250,8 @@ AS WITH dados_anonimizados_demo_vicosa AS (
     SELECT 
         municipio_id_sus,
     	impulso_previne_dados_nominais.equipe_ine(municipio_id_sus::text, equipe_ine) AS equipe_ine,
-        MAX(GREATEST(consulta_prenatal_ultima_data::date, acs_data_ultima_visita::date)) AS dt_registro_producao_mais_recente,
-        MIN(LEAST(consulta_prenatal_ultima_data::date, acs_data_ultima_visita::date)) AS dt_registro_producao_mais_antigo
+        MAX(GREATEST(consulta_prenatal_ultima_data::date)) AS dt_registro_producao_mais_recente,
+        MIN(LEAST(consulta_prenatal_ultima_data::date) AS dt_registro_producao_mais_antigo
     FROM une_as_bases
     GROUP BY 1, 2
 )

--- a/bd_analitico/esus-backups/impulso_previne_dados_nominais/views_materializadas/painel_coordenadores_lista_nominal_gestantes.sql
+++ b/bd_analitico/esus-backups/impulso_previne_dados_nominais/views_materializadas/painel_coordenadores_lista_nominal_gestantes.sql
@@ -246,7 +246,16 @@ AS WITH dados_anonimizados_demo_vicosa AS (
             dados_transmissoes_recentes.municipio_id_sus
            FROM dados_transmissoes_recentes
         )
- SELECT tb1.municipio_id_sus,
+, data_registro_producao AS (
+    SELECT 
+        municipio_id_sus,
+    	impulso_previne_dados_nominais.equipe_ine(municipio_id_sus::text, equipe_ine) AS equipe_ine,
+        MAX(GREATEST(consulta_prenatal_ultima_data::date, acs_data_ultima_visita::date)) AS dt_registro_producao_mais_recente,
+        MIN(LEAST(consulta_prenatal_ultima_data::date, acs_data_ultima_visita::date)) AS dt_registro_producao_mais_antigo
+    FROM une_as_bases
+    GROUP BY 1, 2
+)
+, tabela_aux as(SELECT tb1.municipio_id_sus,
     concat(m.nome, ' - ', m.uf_sigla) AS municipio_uf,
     tb1.estabelecimento_cnes,
     tb1.estabelecimento_nome,
@@ -306,6 +315,13 @@ AS WITH dados_anonimizados_demo_vicosa AS (
     tb1.criacao_data
    FROM une_as_bases tb1
      JOIN listas_de_codigos.municipios m ON tb1.municipio_id_sus::bpchar = m.id_sus
+) SELECT
+    tabela_aux.*,
+    drp.dt_registro_producao_mais_recente
+FROM tabela_aux
+LEFT JOIN data_registro_producao drp 
+    ON drp.municipio_id_sus = tabela_aux.municipio_id_sus
+    AND drp.equipe_ine = tabela_aux.equipe_ine
 WITH DATA;
 
 -- View indexes:

--- a/bd_analitico/esus-backups/impulso_previne_dados_nominais/views_materializadas/painel_enfermeiras_lista_nominal_diabeticos.sql
+++ b/bd_analitico/esus-backups/impulso_previne_dados_nominais/views_materializadas/painel_enfermeiras_lista_nominal_diabeticos.sql
@@ -263,6 +263,16 @@ AS WITH dados_anonimizados_demo_vicosa AS (
             dados_transmissoes_recentes.criacao_data
            FROM dados_transmissoes_recentes
         )
+, data_registro_producao AS (
+    SELECT 
+        municipio_id_sus,
+    	impulso_previne_dados_nominais.equipe_ine(municipio_id_sus::text, COALESCE(equipe_ine_cadastro, equipe_ine_atendimento)) AS equipe_ine_cadastro,
+        MAX(GREATEST(dt_solicitacao_hemoglobina_glicada_mais_recente::date,dt_consulta_mais_recente::date,data_ultimo_cadastro::date,dt_ultima_consulta::date)) AS dt_registro_producao_mais_recente,
+        MIN(LEAST(dt_solicitacao_hemoglobina_glicada_mais_recente::date,dt_consulta_mais_recente::date,data_ultimo_cadastro::date,dt_ultima_consulta::date)) AS dt_registro_producao_mais_antigo
+    FROM une_as_bases
+    GROUP BY 1, 2
+)
+, tabela_aux as (          
  SELECT tb1.municipio_id_sus,
     concat(tb2.nome, ' - ', tb2.uf_sigla) AS municipio_uf,
     tb1.quadrimestre_atual,
@@ -349,4 +359,12 @@ AS WITH dados_anonimizados_demo_vicosa AS (
    FROM une_as_bases tb1
      LEFT JOIN listas_de_codigos.municipios tb2 ON tb1.municipio_id_sus::bpchar = tb2.id_sus
   WHERE COALESCE(tb1.se_faleceu, 0) <> 1
+  )
+SELECT
+    tabela_aux.*,
+    drp.dt_registro_producao_mais_recente
+FROM tabela_aux
+LEFT JOIN data_registro_producao drp 
+    ON drp.municipio_id_sus = tabela_aux.municipio_id_sus
+    AND drp.equipe_ine_cadastro = tabela_aux.equipe_ine_cadastro
 WITH DATA;

--- a/bd_analitico/esus-backups/impulso_previne_dados_nominais/views_materializadas/painel_enfermeiras_lista_nominal_gestantes.sql
+++ b/bd_analitico/esus-backups/impulso_previne_dados_nominais/views_materializadas/painel_enfermeiras_lista_nominal_gestantes.sql
@@ -250,8 +250,8 @@ AS WITH dados_anonimizados_demo_vicosa AS (
     SELECT 
         municipio_id_sus,
     	impulso_previne_dados_nominais.equipe_ine(municipio_id_sus::text, equipe_ine) AS equipe_ine,
-        MAX(GREATEST(consulta_prenatal_ultima_data::date, acs_data_ultima_visita::date)) AS dt_registro_producao_mais_recente,
-        MIN(LEAST(consulta_prenatal_ultima_data::date, acs_data_ultima_visita::date)) AS dt_registro_producao_mais_antigo
+        MAX(GREATEST(consulta_prenatal_ultima_data::date)) AS dt_registro_producao_mais_recente,
+        MIN(LEAST(consulta_prenatal_ultima_data::date)) AS dt_registro_producao_mais_antigo
     FROM une_as_bases
     GROUP BY 1, 2
 )

--- a/bd_analitico/esus-backups/impulso_previne_dados_nominais/views_materializadas/painel_enfermeiras_lista_nominal_gestantes.sql
+++ b/bd_analitico/esus-backups/impulso_previne_dados_nominais/views_materializadas/painel_enfermeiras_lista_nominal_gestantes.sql
@@ -246,7 +246,16 @@ AS WITH dados_anonimizados_demo_vicosa AS (
             dados_transmissoes_recentes.municipio_id_sus
            FROM dados_transmissoes_recentes
         )
- SELECT tb1.municipio_id_sus,
+, data_registro_producao AS (
+    SELECT 
+        municipio_id_sus,
+    	impulso_previne_dados_nominais.equipe_ine(municipio_id_sus::text, equipe_ine) AS equipe_ine,
+        MAX(GREATEST(consulta_prenatal_ultima_data::date, acs_data_ultima_visita::date)) AS dt_registro_producao_mais_recente,
+        MIN(LEAST(consulta_prenatal_ultima_data::date, acs_data_ultima_visita::date)) AS dt_registro_producao_mais_antigo
+    FROM une_as_bases
+    GROUP BY 1, 2
+)
+, tabela_aux as (SELECT tb1.municipio_id_sus,
     concat(m.nome, ' - ', m.uf_sigla) AS municipio_uf,
     tb1.estabelecimento_cnes,
     tb1.estabelecimento_nome,
@@ -300,4 +309,12 @@ AS WITH dados_anonimizados_demo_vicosa AS (
    FROM une_as_bases tb1
      JOIN listas_de_codigos.municipios m ON tb1.municipio_id_sus::bpchar = m.id_sus
   WHERE tb1.gestante_consulta_prenatal_data_limite >= CURRENT_DATE
+  )
+SELECT
+    tabela_aux.*,
+    drp.dt_registro_producao_mais_recente
+FROM tabela_aux
+LEFT JOIN data_registro_producao drp 
+    ON drp.municipio_id_sus = tabela_aux.municipio_id_sus
+    AND drp.equipe_ine = tabela_aux.equipe_ine
 WITH DATA;


### PR DESCRIPTION
_**Alterações de código das listas nominais**_

**Motivo do ajuste:**
Melhoria dos paineis das listas nominais.

**O que está sendo alterado:**
Nos códigos atuais e futuros dos paineis das listas nominais é adicionada uma CTE que calcula por municipio e equipe quais as datas de produção mais recente e mais antigas, com base nas datas dos últimos atendimentos e últimos cadastros recebidos nas transmissões mais recentes de cada lista.


_**Validações obrigatórias**_

(Se modelagem no banco de dados)
- [x] Código ajustado funcionando no bd analítico

- [x] Check duplicados e variação de linhas 
- [] Check variações denominador e numerador do quadrimestre atual por município 

[Análises quantitativas nessa planilha](https://docs.google.com/spreadsheets/d/1SPUdqwJALbeaQgZTZaulcwtyzG5Yl41j3XNGnUZFuhI/edit#gid=0)
