### PR TITLE
Correção do calculo de prazos dos numeradores da listas de crônicos e citopatológico

### DIFF
--- a/transmissor_impulso_esus/lista_nominal_citopatologico.sql
+++ b/transmissor_impulso_esus/lista_nominal_citopatologico.sql
@@ -279,23 +279,23 @@ indicador_regras_de_negocio as (
 		tb2.data_ultimo_exame,
 		date_part('year', age(tb2.data_ultimo_exame ::timestamp with time zone, tb1.data_de_nascimento::timestamp with time zone))::integer as idade_realizou_ultimo_exame,
 		CASE
-			WHEN (CURRENT_DATE - tb2.data_ultimo_exame) <= 1095 and (date_part('year', age(tb2.data_ultimo_exame ::timestamp with time zone, tb1.data_de_nascimento::timestamp with time zone)))::integer between 25 and 64 THEN TRUE
+			WHEN CURRENT_DATE - INTERVAL '36 months' <= tb2.data_ultimo_exame and (date_part('year', age(tb2.data_ultimo_exame ::timestamp with time zone, tb1.data_de_nascimento::timestamp with time zone)))::integer between 25 and 64 THEN TRUE
 			ELSE FALSE
 		END AS realizou_exame_ultimos_36_meses,
-		(tb2.data_ultimo_exame + 1095) AS ultimo_exame_mais_36_meses,
+		(tb2.data_ultimo_exame + INTERVAL '36 months') AS ultimo_exame_mais_36_meses,
 		CASE
-			WHEN date_part('month', (tb2.data_ultimo_exame + 1095)) >= 1::double precision AND date_part('month', (tb2.data_ultimo_exame + 1095)) <= 4::double precision THEN concat(date_part('year', (tb2.data_ultimo_exame + 1095)), '.Q1')
-			WHEN date_part('month', (tb2.data_ultimo_exame + 1095)) >= 5::double precision AND date_part('month', (tb2.data_ultimo_exame + 1095)) <= 8::double precision THEN concat(date_part('year', (tb2.data_ultimo_exame + 1095)), '.Q2')
-			WHEN date_part('month', (tb2.data_ultimo_exame + 1095)) >= 9::double precision AND date_part('month', (tb2.data_ultimo_exame + 1095)) <= 12::double precision THEN concat(date_part('year', (tb2.data_ultimo_exame + 1095)), '.Q3')
+			WHEN date_part('month', (tb2.data_ultimo_exame + INTERVAL '36 months')) >= 1::double precision AND date_part('month', (tb2.data_ultimo_exame + INTERVAL '36 months')) <= 4::double precision THEN concat(date_part('year', (tb2.data_ultimo_exame + INTERVAL '36 months')), '.Q1')
+			WHEN date_part('month', (tb2.data_ultimo_exame + INTERVAL '36 months')) >= 5::double precision AND date_part('month', (tb2.data_ultimo_exame + INTERVAL '36 months')) <= 8::double precision THEN concat(date_part('year', (tb2.data_ultimo_exame + INTERVAL '36 months')), '.Q2')
+			WHEN date_part('month', (tb2.data_ultimo_exame + INTERVAL '36 months')) >= 9::double precision AND date_part('month', (tb2.data_ultimo_exame + INTERVAL '36 months')) <= 12::double precision THEN concat(date_part('year', (tb2.data_ultimo_exame + INTERVAL '36 months')), '.Q3')
 			ELSE 'exame_nunca_realizado'
 		END AS quadrimestre_a_realizar_proximo_exame,
 		CASE
 			WHEN tb2.data_ultimo_exame IS NULL 
 			or (tb2.data_ultimo_exame + INTERVAL '36 months') < current_date 
 			or ((CASE
-						WHEN date_part('month', (tb2.data_ultimo_exame + 1095)) >= 1::double precision AND date_part('month', (tb2.data_ultimo_exame + 1095)) <= 4::double precision THEN concat(date_part('year', (tb2.data_ultimo_exame + 1095)), '.Q1')
-						WHEN date_part('month', (tb2.data_ultimo_exame + 1095)) >= 5::double precision AND date_part('month', (tb2.data_ultimo_exame + 1095)) <= 8::double precision THEN concat(date_part('year', (tb2.data_ultimo_exame + 1095)), '.Q2')
-						WHEN date_part('month', (tb2.data_ultimo_exame + 1095)) >= 9::double precision AND date_part('month', (tb2.data_ultimo_exame + 1095)) <= 12::double precision THEN concat(date_part('year', (tb2.data_ultimo_exame + 1095)), '.Q3')
+						WHEN date_part('month', (tb2.data_ultimo_exame + INTERVAL '36 months')) >= 1::double precision AND date_part('month', (tb2.data_ultimo_exame + INTERVAL '36 months')) <= 4::double precision THEN concat(date_part('year', (tb2.data_ultimo_exame + INTERVAL '36 months')), '.Q1')
+						WHEN date_part('month', (tb2.data_ultimo_exame + INTERVAL '36 months')) >= 5::double precision AND date_part('month', (tb2.data_ultimo_exame + INTERVAL '36 months')) <= 8::double precision THEN concat(date_part('year', (tb2.data_ultimo_exame + INTERVAL '36 months')), '.Q2')
+						WHEN date_part('month', (tb2.data_ultimo_exame + INTERVAL '36 months')) >= 9::double precision AND date_part('month', (tb2.data_ultimo_exame + INTERVAL '36 months')) <= 12::double precision THEN concat(date_part('year', (tb2.data_ultimo_exame + INTERVAL '36 months')), '.Q3')
 				  END ) = ( CASE
 								WHEN date_part('month', current_date) >= 1::double precision AND date_part('month', current_date) <= 4::double precision THEN concat(date_part('year', current_date), '.Q1')
 								WHEN date_part('month', current_date) >= 5::double precision AND date_part('month', current_date) <= 8::double precision THEN concat(date_part('year', current_date), '.Q2')
@@ -303,7 +303,7 @@ indicador_regras_de_negocio as (
 							end 
 			) 
 			)
-			or date_part('year', age(tb2.data_ultimo_exame ::timestamp with time zone, tb1.data_de_nascimento::timestamp with time zone)) < 25 and ((tb2.data_ultimo_exame + 1095)::date - current_date) > 0
+			or date_part('year', age(tb2.data_ultimo_exame ::timestamp with time zone, tb1.data_de_nascimento::timestamp with time zone)) < 25 and ((tb2.data_ultimo_exame + INTERVAL '36 months')::date - current_date) > 0
 			THEN (
 				CASE
 					WHEN date_part('month', CURRENT_DATE) >= 1 AND date_part('month', CURRENT_DATE) <= 4 THEN concat(date_part('year', CURRENT_DATE::date), '-04-30')::date
@@ -314,19 +314,19 @@ indicador_regras_de_negocio as (
 			ELSE (tb2.data_ultimo_exame + INTERVAL '36 months')::date
 		END AS data_limite_a_realizar_proximo_exame,
 		CASE
-			when date_part('year', age(tb2.data_ultimo_exame ::timestamp with time zone, tb1.data_de_nascimento::timestamp with time zone)) < 25 and ((tb2.data_ultimo_exame + 1095)::date - current_date) > 0 then 'exame_realizado_antes_dos_25'
+			when date_part('year', age(tb2.data_ultimo_exame ::timestamp with time zone, tb1.data_de_nascimento::timestamp with time zone)) < 25 and ((tb2.data_ultimo_exame + INTERVAL '36 months')::date - current_date) > 0 then 'exame_realizado_antes_dos_25'
 			WHEN (CASE
-						WHEN date_part('month', (tb2.data_ultimo_exame + 1095)) >= 1::double precision AND date_part('month', (tb2.data_ultimo_exame + 1095)) <= 4::double precision THEN concat(date_part('year', (tb2.data_ultimo_exame + 1095)), '.Q1')
-						WHEN date_part('month', (tb2.data_ultimo_exame + 1095)) >= 5::double precision AND date_part('month', (tb2.data_ultimo_exame + 1095)) <= 8::double precision THEN concat(date_part('year', (tb2.data_ultimo_exame + 1095)), '.Q2')
-						WHEN date_part('month', (tb2.data_ultimo_exame + 1095)) >= 9::double precision AND date_part('month', (tb2.data_ultimo_exame + 1095)) <= 12::double precision THEN concat(date_part('year', (tb2.data_ultimo_exame + 1095)), '.Q3')
+						WHEN date_part('month', (tb2.data_ultimo_exame + INTERVAL '36 months')) >= 1::double precision AND date_part('month', (tb2.data_ultimo_exame + INTERVAL '36 months')) <= 4::double precision THEN concat(date_part('year', (tb2.data_ultimo_exame + INTERVAL '36 months')), '.Q1')
+						WHEN date_part('month', (tb2.data_ultimo_exame + INTERVAL '36 months')) >= 5::double precision AND date_part('month', (tb2.data_ultimo_exame + INTERVAL '36 months')) <= 8::double precision THEN concat(date_part('year', (tb2.data_ultimo_exame + INTERVAL '36 months')), '.Q2')
+						WHEN date_part('month', (tb2.data_ultimo_exame + INTERVAL '36 months')) >= 9::double precision AND date_part('month', (tb2.data_ultimo_exame + INTERVAL '36 months')) <= 12::double precision THEN concat(date_part('year', (tb2.data_ultimo_exame + INTERVAL '36 months')), '.Q3')
 				  END ) = ( CASE
 								WHEN date_part('month', current_date) >= 1::double precision AND date_part('month', current_date) <= 4::double precision THEN concat(date_part('year', current_date), '.Q1')
 								WHEN date_part('month', current_date) >= 5::double precision AND date_part('month', current_date) <= 8::double precision THEN concat(date_part('year', current_date), '.Q2')
 								WHEN date_part('month', current_date) >= 9::double precision AND date_part('month', current_date) <= 12::double precision THEN concat(date_part('year', current_date), '.Q3')
 							end 
 			) THEN 'exame_vence_no_quadrimestre_atual'			
-			WHEN ((tb2.data_ultimo_exame + 1095)::date - current_date) < 0 THEN 'exame_vencido'
-			WHEN ((tb2.data_ultimo_exame + 1095)::date - current_date) > 0 THEN 'exame_em_dia'
+			WHEN ((tb2.data_ultimo_exame + INTERVAL '36 months')::date - current_date) < 0 THEN 'exame_vencido'
+			WHEN ((tb2.data_ultimo_exame + INTERVAL '36 months')::date - current_date) > 0 THEN 'exame_em_dia'
 			when tb2.data_ultimo_exame is null then 'exame_nunca_realizado'
 			else 'status'
 		END as status_exame,

--- a/transmissor_impulso_esus/lista_nominal_citopatologico.sql
+++ b/transmissor_impulso_esus/lista_nominal_citopatologico.sql
@@ -291,7 +291,7 @@ indicador_regras_de_negocio as (
 		END AS quadrimestre_a_realizar_proximo_exame,
 		CASE
 			WHEN tb2.data_ultimo_exame IS NULL 
-			or (tb2.data_ultimo_exame + INTERVAL '1095 days') < current_date 
+			or (tb2.data_ultimo_exame + INTERVAL '36 months') < current_date 
 			or ((CASE
 						WHEN date_part('month', (tb2.data_ultimo_exame + 1095)) >= 1::double precision AND date_part('month', (tb2.data_ultimo_exame + 1095)) <= 4::double precision THEN concat(date_part('year', (tb2.data_ultimo_exame + 1095)), '.Q1')
 						WHEN date_part('month', (tb2.data_ultimo_exame + 1095)) >= 5::double precision AND date_part('month', (tb2.data_ultimo_exame + 1095)) <= 8::double precision THEN concat(date_part('year', (tb2.data_ultimo_exame + 1095)), '.Q2')
@@ -311,7 +311,7 @@ indicador_regras_de_negocio as (
 					WHEN date_part('month', CURRENT_DATE) >= 9 AND date_part('month', CURRENT_DATE) <= 12 THEN concat(date_part('year', CURRENT_DATE::date), '-12-31')::date
 				END
 			)
-			ELSE (tb2.data_ultimo_exame + INTERVAL '1095 days')::date
+			ELSE (tb2.data_ultimo_exame + INTERVAL '36 months')::date
 		END AS data_limite_a_realizar_proximo_exame,
 		CASE
 			when date_part('year', age(tb2.data_ultimo_exame ::timestamp with time zone, tb1.data_de_nascimento::timestamp with time zone)) < 25 and ((tb2.data_ultimo_exame + 1095)::date - current_date) > 0 then 'exame_realizado_antes_dos_25'

--- a/transmissor_impulso_esus/lista_nominal_diabeticos.sql
+++ b/transmissor_impulso_esus/lista_nominal_diabeticos.sql
@@ -233,7 +233,7 @@ WITH possui_diabetes_autoreferida AS (
 				WHEN date_part('month'::text, current_date) >= 5::double precision AND date_part('month'::text, current_date) <= 8::double precision THEN concat(date_part('year'::text, current_date), '-08-31')
 				WHEN date_part('month'::text, current_date) >= 9::double precision AND date_part('month'::text, current_date) <= 12::double precision THEN concat(date_part('year'::text, current_date), '-12-31')
 				ELSE NULL::text
-			END::date - '180 days'::interval) THEN true
+			END::date - '6 months'::interval) THEN true
 			ELSE false
 		END AS realizou_solicitacao_hemoglobina_ultimos_6_meses,
 		hg.dt_solicitacao_hemoglobina_glicada_mais_recente,
@@ -250,7 +250,7 @@ WITH possui_diabetes_autoreferida AS (
 				WHEN date_part('month'::text, current_date) >= 5::double precision AND date_part('month'::text, current_date) <= 8::double precision THEN concat(date_part('year'::text, current_date), '-08-31')
 				WHEN date_part('month'::text, current_date) >= 9::double precision AND date_part('month'::text, current_date) <= 12::double precision THEN concat(date_part('year'::text, current_date), '-12-31')
 				ELSE NULL::text
-			END::date - '180 days'::interval) THEN true
+			END::date - '6 months'::interval) THEN true
 			ELSE false
 		END AS realizou_consulta_ultimos_6_meses,
 	cd.dt_consulta_mais_recente,

--- a/transmissor_impulso_esus/lista_nominal_hipertensos.sql
+++ b/transmissor_impulso_esus/lista_nominal_hipertensos.sql
@@ -234,7 +234,7 @@ WITH possui_hipertensao_autorreferida AS (
                 WHEN date_part('month'::text, current_date) >= 5::double precision AND date_part('month'::text, current_date) <= 8::double precision THEN concat(date_part('year'::text, current_date), '-08-31')
                 WHEN date_part('month'::text, current_date) >= 9::double precision AND date_part('month'::text, current_date) <= 12::double precision THEN concat(date_part('year'::text, current_date), '-12-31')
                 ELSE NULL::text
-            END::date - '180 days'::interval) THEN true
+            END::date - '6 months'::interval) THEN true
             ELSE false
         END AS realizou_afericao_ultimos_6_meses,
         ap.dt_afericao_pressao_mais_recente,
@@ -251,7 +251,7 @@ WITH possui_hipertensao_autorreferida AS (
                 WHEN date_part('month'::text, current_date) >= 5::double precision AND date_part('month'::text, current_date) <= 8::double precision THEN concat(date_part('year'::text, current_date), '-08-31')
                 WHEN date_part('month'::text, current_date) >= 9::double precision AND date_part('month'::text, current_date) <= 12::double precision THEN concat(date_part('year'::text, current_date), '-12-31')
                 ELSE NULL::text
-            END::date - '180 days'::interval) THEN true
+            END::date - '6 months'::interval) THEN true
             ELSE false
         END AS realizou_consulta_ultimos_6_meses,
     ch.dt_consulta_mais_recente,

--- a/validacoes_listas_nominais/validacoes_ajustes_lista_nominal_citopatologico.sql
+++ b/validacoes_listas_nominais/validacoes_ajustes_lista_nominal_citopatologico.sql
@@ -1,0 +1,51 @@
+-- AJUSTES NO CÓDIGO DO TRANSMISSOR
+-- Checar duplicações
+, duplicados AS (
+    SELECT 
+        'backup - Juquitiba - SP' AS municipio_uf, -- Nome do backup testado
+        COUNT(1) AS cont_linhas,
+        COUNT(DISTINCT chave_mulher) AS cont_chaves_nominais_distintas
+    FROM aux1 
+    GROUP BY 1
+)
+-- Checar denominador e numerador
+, dem_num AS (
+    SELECT
+        'backup - Juquitiba - SP' AS municipio_uf, -- Nome do backup testado
+        count(DISTINCT l.chave_mulher) AS denominador_cito,
+        count(DISTINCT CASE WHEN l.realizou_exame_ultimos_36_meses IS TRUE 
+                                THEN l.chave_mulher
+                        END) AS numerador_cito
+    FROM aux1 l
+    GROUP BY 1
+)
+SELECT 
+    *
+FROM dem_num
+
+-- AJUSTES NA VIEW DO PAINEL 
+-- Checar duplicações
+, duplicados AS (
+    SELECT 
+        municipio_id_sus,
+        COUNT(1) AS cont_linhas,
+        COUNT(DISTINCT l.paciente_nome||l.cidadao_cpf_dt_nascimento||l.municipio_id_sus) AS cont_chaves_nominais_distintas
+    FROM impulso_previne_dados_nominais.painel_citopatologico_lista_nominal   -- Adicionar CTE com o resultado final da consulta da lista nominal 
+    GROUP BY 1
+)
+-- Checar denominador e numerador
+, dem_num AS (
+    SELECT
+        concat(m.nome, ' - ', m.uf_sigla) AS municipio_uf,
+        count(DISTINCT l.paciente_nome||l.cidadao_cpf_dt_nascimento||l.municipio_id_sus) AS denominador_cito,
+        count(DISTINCT CASE WHEN l.realizou_exame_ultimos_36_meses IS TRUE 
+                                THEN l.paciente_nome||l.cidadao_cpf_dt_nascimento||municipio_id_sus
+                        END) AS numerador_cito
+    FROM impulso_previne_dados_nominais.painel_citopatologico_lista_nominal -- Adicionar CTE com o resultado final da consulta da lista nominal
+    LEFT JOIN listas_de_codigos.municipios m 
+        ON m.id_sus = l.municipio_id_sus
+    GROUP BY 1
+)
+SELECT 
+    *
+FROM dem_num


### PR DESCRIPTION
_**Alterações de código das listas nominais**_

**Motivo do ajuste:**
O prazo para contabilização dos numerados é em meses segundo a Nota Técnica. Nosso cálculo estava sendo feito em dias, o que levava a alguns dias de diferença ao contabilizar consultas, exames e procedimentos

**O que está sendo alterado:**
Intervalos de contabilização foram trocados de dias para meses
Exemplo: 
De` '180 days'::interval `para ->  ` '6 months'::interval`

- Extra: subindo arquivo com a consulta de validação das modelagens de citopatológico


_**Validações obrigatórias**_

(Se código de transmissão)
- [x] Código ajustado funcionando no back-up (backup de Juquitiba)

[Códigos sql para validações quantitativas - Scripts/validacoes_listas_nominais](https://github.com/ImpulsoGov/bd/tree/b3e45be01efc4e82ce4985ed4df9af6d0f286a41/Scripts/validacoes_listas_nominais))
- [x] Check duplicados e variação de linhas 
Lista de cito está com 4 linhas duplicadas, mas que não foi causado pela alteração. A ser investigado em breve
- [x] Check variações denominador e numerador do quadrimestre atual por município 
Foram encontradas pouca variações para cima no numerador, como era esperado no ajuste da regra

[Análises quantitativas nessa planilha](https://docs.google.com/spreadsheets/d/10zdU-Vi7QEQHtKDew6DWIs1XhvSctzbWbUBOPQ3aHVQ/edit#gid=0)
