### PR TITLE
Correção da janela de observação da gestação para os 3 numeradores de pré-natal - painel coordenadora

### DIFF
--- a/bd_analitico/esus-backups/impulso_previne_dados_nominais/views_materializadas/painel_coordenadores_lista_nominal_gestantes.sql
+++ b/bd_analitico/esus-backups/impulso_previne_dados_nominais/views_materializadas/painel_coordenadores_lista_nominal_gestantes.sql
@@ -19,13 +19,13 @@ AS WITH dados_anonimizados_demo_vicosa AS (
             res.gestacao_data_dpp,
             res.gestacao_data_dpp AS gestante_consulta_prenatal_data_limite,
             res.gestacao_dpp_dias_para,
-            res.consultas_prenatal_total,
+            res.consultas_pre_natal_validas,
             res.consulta_prenatal_ultima_data,
             res.consulta_prenatal_ultima_dias_desde,
-            res.atendimento_odontologico_realizado,
-            res.exame_hiv_realizado,
-            res.exame_sifilis_realizado,
-            res.exame_sifilis_hiv_realizado,
+            res.atendimento_odontologico_realizado_valido,
+            res.exame_hiv_realizado_valido,
+            res.exame_sifilis_realizado_valido,
+            res.exame_sifilis_hiv_realizado_valido,
             res.possui_registro_aborto,
             res.possui_registro_parto,
             res.criacao_data,
@@ -51,13 +51,13 @@ AS WITH dados_anonimizados_demo_vicosa AS (
                     concat(impulso_previne_dados_nominais.random_between(100000000, 999999999)::text, impulso_previne_dados_nominais.random_between(10, 99)::text) AS gestante_documento_cpf,
                     concat('7', impulso_previne_dados_nominais.random_between(100000000, 999999999)::text, impulso_previne_dados_nominais.random_between(10000, 99999)::text) AS gestante_documento_cns,
                     lista_nominal_gestantes.gestacao_idade_gestacional_atual,
-                    lista_nominal_gestantes.consultas_prenatal_total,
-                    lista_nominal_gestantes.atendimento_odontologico_realizado,
-                    lista_nominal_gestantes.exame_hiv_realizado,
-                    lista_nominal_gestantes.exame_sifilis_realizado,
+                    lista_nominal_gestantes.consultas_pre_natal_validas,
+                    lista_nominal_gestantes.atendimento_odontologico_realizado_valido,
+                    lista_nominal_gestantes.exame_hiv_realizado_valido,
+                    lista_nominal_gestantes.exame_sifilis_realizado_valido,
                     lista_nominal_gestantes.possui_registro_aborto,
                     lista_nominal_gestantes.possui_registro_parto,
-                    lista_nominal_gestantes.exame_sifilis_hiv_realizado,
+                    lista_nominal_gestantes.exame_sifilis_hiv_realizado_valido,
                     lista_nominal_gestantes.criacao_data
                    FROM impulso_previne_dados_nominais.lista_nominal_gestantes_unificada lista_nominal_gestantes
                   WHERE lista_nominal_gestantes.municipio_id_sus::text = '317130'::text) res
@@ -81,13 +81,13 @@ AS WITH dados_anonimizados_demo_vicosa AS (
             res.gestacao_data_dpp,
             res.gestacao_data_dpp AS gestante_consulta_prenatal_data_limite,
             res.gestacao_dpp_dias_para,
-            res.consultas_prenatal_total,
+            res.consultas_pre_natal_validas,
             res.consulta_prenatal_ultima_data,
             res.consulta_prenatal_ultima_dias_desde,
-            res.atendimento_odontologico_realizado,
-            res.exame_hiv_realizado,
-            res.exame_sifilis_realizado,
-            res.exame_sifilis_hiv_realizado,
+            res.atendimento_odontologico_realizado_valido,
+            res.exame_hiv_realizado_valido,
+            res.exame_sifilis_realizado_valido,
+            res.exame_sifilis_hiv_realizado_valido,
             res.possui_registro_aborto,
             res.possui_registro_parto,
             res.criacao_data,
@@ -113,13 +113,13 @@ AS WITH dados_anonimizados_demo_vicosa AS (
                     concat(impulso_previne_dados_nominais.random_between(100000000, 999999999)::text, impulso_previne_dados_nominais.random_between(10, 99)::text) AS gestante_documento_cpf,
                     concat('7', impulso_previne_dados_nominais.random_between(100000000, 999999999)::text, impulso_previne_dados_nominais.random_between(10000, 99999)::text) AS gestante_documento_cns,
                     lista_nominal_gestantes.gestacao_idade_gestacional_atual,
-                    lista_nominal_gestantes.consultas_prenatal_total,
-                    lista_nominal_gestantes.atendimento_odontologico_realizado,
-                    lista_nominal_gestantes.exame_hiv_realizado,
-                    lista_nominal_gestantes.exame_sifilis_realizado,
+                    lista_nominal_gestantes.consultas_pre_natal_validas,
+                    lista_nominal_gestantes.atendimento_odontologico_realizado_valido,
+                    lista_nominal_gestantes.exame_hiv_realizado_valido,
+                    lista_nominal_gestantes.exame_sifilis_realizado_valido,
                     lista_nominal_gestantes.possui_registro_aborto,
                     lista_nominal_gestantes.possui_registro_parto,
-                    lista_nominal_gestantes.exame_sifilis_hiv_realizado,
+                    lista_nominal_gestantes.exame_sifilis_hiv_realizado_valido,
                     lista_nominal_gestantes.criacao_data
                    FROM impulso_previne_dados_nominais.lista_nominal_gestantes_unificada lista_nominal_gestantes
                   WHERE lista_nominal_gestantes.municipio_id_sus::text = '317130'::text) res
@@ -143,13 +143,13 @@ AS WITH dados_anonimizados_demo_vicosa AS (
             tb1_1.gestacao_data_dpp,
             tb1_1.gestacao_data_dpp AS gestante_consulta_prenatal_data_limite,
             tb1_1.gestacao_dpp_dias_para,
-            tb1_1.consultas_prenatal_total,
+            tb1_1.consultas_pre_natal_validas,
             tb1_1.consulta_prenatal_ultima_data,
             tb1_1.consulta_prenatal_ultima_dias_desde,
-            tb1_1.atendimento_odontologico_realizado,
-            tb1_1.exame_hiv_realizado,
-            tb1_1.exame_sifilis_realizado,
-            tb1_1.exame_sifilis_hiv_realizado,
+            tb1_1.atendimento_odontologico_realizado_valido,
+            tb1_1.exame_hiv_realizado_valido,
+            tb1_1.exame_sifilis_realizado_valido,
+            tb1_1.exame_sifilis_hiv_realizado_valido,
             tb1_1.possui_registro_aborto,
             tb1_1.possui_registro_parto,
             tb1_1.criacao_data,
@@ -173,13 +173,13 @@ AS WITH dados_anonimizados_demo_vicosa AS (
             dados_anonimizados_demo_vicosa.gestacao_data_dpp,
             dados_anonimizados_demo_vicosa.gestante_consulta_prenatal_data_limite,
             dados_anonimizados_demo_vicosa.gestacao_dpp_dias_para,
-            dados_anonimizados_demo_vicosa.consultas_prenatal_total,
+            dados_anonimizados_demo_vicosa.consultas_pre_natal_validas,
             dados_anonimizados_demo_vicosa.consulta_prenatal_ultima_data,
             dados_anonimizados_demo_vicosa.consulta_prenatal_ultima_dias_desde,
-            dados_anonimizados_demo_vicosa.atendimento_odontologico_realizado,
-            dados_anonimizados_demo_vicosa.exame_hiv_realizado,
-            dados_anonimizados_demo_vicosa.exame_sifilis_realizado,
-            dados_anonimizados_demo_vicosa.exame_sifilis_hiv_realizado,
+            dados_anonimizados_demo_vicosa.atendimento_odontologico_realizado_valido,
+            dados_anonimizados_demo_vicosa.exame_hiv_realizado_valido,
+            dados_anonimizados_demo_vicosa.exame_sifilis_realizado_valido,
+            dados_anonimizados_demo_vicosa.exame_sifilis_hiv_realizado_valido,
             dados_anonimizados_demo_vicosa.possui_registro_aborto,
             dados_anonimizados_demo_vicosa.possui_registro_parto,
             dados_anonimizados_demo_vicosa.criacao_data,
@@ -203,13 +203,13 @@ AS WITH dados_anonimizados_demo_vicosa AS (
             dados_anonimizados_impulsolandia.gestacao_data_dpp,
             dados_anonimizados_impulsolandia.gestante_consulta_prenatal_data_limite,
             dados_anonimizados_impulsolandia.gestacao_dpp_dias_para,
-            dados_anonimizados_impulsolandia.consultas_prenatal_total,
+            dados_anonimizados_impulsolandia.consultas_pre_natal_validas,
             dados_anonimizados_impulsolandia.consulta_prenatal_ultima_data,
             dados_anonimizados_impulsolandia.consulta_prenatal_ultima_dias_desde,
-            dados_anonimizados_impulsolandia.atendimento_odontologico_realizado,
-            dados_anonimizados_impulsolandia.exame_hiv_realizado,
-            dados_anonimizados_impulsolandia.exame_sifilis_realizado,
-            dados_anonimizados_impulsolandia.exame_sifilis_hiv_realizado,
+            dados_anonimizados_impulsolandia.atendimento_odontologico_realizado_valido,
+            dados_anonimizados_impulsolandia.exame_hiv_realizado_valido,
+            dados_anonimizados_impulsolandia.exame_sifilis_realizado_valido,
+            dados_anonimizados_impulsolandia.exame_sifilis_hiv_realizado_valido,
             dados_anonimizados_impulsolandia.possui_registro_aborto,
             dados_anonimizados_impulsolandia.possui_registro_parto,
             dados_anonimizados_impulsolandia.criacao_data,
@@ -233,13 +233,13 @@ AS WITH dados_anonimizados_demo_vicosa AS (
             dados_transmissoes_recentes.gestacao_data_dpp,
             dados_transmissoes_recentes.gestante_consulta_prenatal_data_limite,
             dados_transmissoes_recentes.gestacao_dpp_dias_para,
-            dados_transmissoes_recentes.consultas_prenatal_total,
+            dados_transmissoes_recentes.consultas_pre_natal_validas,
             dados_transmissoes_recentes.consulta_prenatal_ultima_data,
             dados_transmissoes_recentes.consulta_prenatal_ultima_dias_desde,
-            dados_transmissoes_recentes.atendimento_odontologico_realizado,
-            dados_transmissoes_recentes.exame_hiv_realizado,
-            dados_transmissoes_recentes.exame_sifilis_realizado,
-            dados_transmissoes_recentes.exame_sifilis_hiv_realizado,
+            dados_transmissoes_recentes.atendimento_odontologico_realizado_valido,
+            dados_transmissoes_recentes.exame_hiv_realizado_valido,
+            dados_transmissoes_recentes.exame_sifilis_realizado_valido,
+            dados_transmissoes_recentes.exame_sifilis_hiv_realizado_valido,
             dados_transmissoes_recentes.possui_registro_aborto,
             dados_transmissoes_recentes.possui_registro_parto,
             dados_transmissoes_recentes.criacao_data,
@@ -251,7 +251,7 @@ AS WITH dados_anonimizados_demo_vicosa AS (
         municipio_id_sus,
     	impulso_previne_dados_nominais.equipe_ine(municipio_id_sus::text, equipe_ine) AS equipe_ine,
         MAX(GREATEST(consulta_prenatal_ultima_data::date)) AS dt_registro_producao_mais_recente,
-        MIN(LEAST(consulta_prenatal_ultima_data::date) AS dt_registro_producao_mais_antigo
+        MIN(LEAST(consulta_prenatal_ultima_data::date)) AS dt_registro_producao_mais_antigo
     FROM une_as_bases
     GROUP BY 1, 2
 )
@@ -259,14 +259,7 @@ AS WITH dados_anonimizados_demo_vicosa AS (
     concat(m.nome, ' - ', m.uf_sigla) AS municipio_uf,
     tb1.estabelecimento_cnes,
     tb1.estabelecimento_nome,
-        CASE
-            WHEN concat(m.nome, ' - ', m.uf_sigla) = 'Lábrea - AM'::text AND (tb1.equipe_ine = ANY (ARRAY['0000010030'::text, '0000010022'::text])) THEN '0EQ01AMLAB'::text::character varying::text
-            WHEN concat(m.nome, ' - ', m.uf_sigla) = 'Lábrea - AM'::text AND (tb1.equipe_ine = ANY (ARRAY['0002219794'::text, '0000009997'::text, '0000009989'::text])) THEN '0EQ02AMLAB'::text::character varying::text
-            WHEN concat(m.nome, ' - ', m.uf_sigla) = 'Lábrea - AM'::text AND (tb1.equipe_ine = ANY (ARRAY['0002230399'::text, '0000009938'::text, '0000009911'::text])) THEN '0EQ03AMLAB'::text::character varying::text
-            WHEN concat(m.nome, ' - ', m.uf_sigla) = 'Lábrea - AM'::text AND (tb1.equipe_ine = ANY (ARRAY['0002212374'::text, '0001623486'::text])) THEN '0EQ04AMLAB'::text::character varying::text
-            WHEN concat(m.nome, ' - ', m.uf_sigla) = 'Lábrea - AM'::text AND (tb1.equipe_ine = ANY (ARRAY['0002231603'::text, '0000010014'::text, '0000010006'::text])) THEN '0EQ05AMLAB'::text::character varying::text
-            ELSE tb1.equipe_ine
-        END AS equipe_ine,
+    impulso_previne_dados_nominais.equipe_ine(tb1.municipio_id_sus::text, tb1.equipe_ine) AS equipe_ine,
     tb1.equipe_nome,
     tb1.acs_nome,
     tb1.acs_data_ultima_visita,
@@ -288,25 +281,25 @@ AS WITH dados_anonimizados_demo_vicosa AS (
         END AS gestante_quadrimestre,
     tb1.gestante_consulta_prenatal_data_limite,
     tb1.gestacao_dpp_dias_para,
-    tb1.consultas_prenatal_total AS gestante_consulta_prenatal_total,
+    tb1.consultas_pre_natal_validas AS gestante_consulta_prenatal_total,
         CASE
-            WHEN tb1.consultas_prenatal_total >= 6 THEN 'Gestantes com 6 consultas ou mais'::text
+            WHEN tb1.consultas_pre_natal_validas >= 6 THEN 'Gestantes com 6 consultas ou mais'::text
             ELSE 'Gestantes com menos de 6 consultas'::text
         END AS gestantes_com_6_consultas,
     tb1.consulta_prenatal_ultima_data AS gestante_consulta_prenatal_ultima_data,
     tb1.consulta_prenatal_ultima_dias_desde AS gestante_consulta_prenatal_ultima_dias_desde,
-    tb1.atendimento_odontologico_realizado,
+    tb1.atendimento_odontologico_realizado_valido AS atendimento_odontologico_realizado,
         CASE
-            WHEN tb1.atendimento_odontologico_realizado = true THEN 'Identificado'::text
-            WHEN tb1.atendimento_odontologico_realizado = false THEN 'Não identificado'::text
+            WHEN tb1.atendimento_odontologico_realizado_valido = true THEN 'Identificado'::text
+            WHEN tb1.atendimento_odontologico_realizado_valido = false THEN 'Não identificado'::text
             ELSE 'Sem dados'::text
         END AS atendimento_odontologico_realizado_identificacao,
-    tb1.exame_hiv_realizado,
-    tb1.exame_sifilis_realizado,
-    tb1.exame_sifilis_hiv_realizado,
+    tb1.exame_hiv_realizado_valido AS exame_hiv_realizado,
+    tb1.exame_sifilis_realizado_valido AS exame_sifilis_realizado,
+    tb1.exame_sifilis_hiv_realizado_valido AS exame_sifilis_hiv_realizado,
         CASE
-            WHEN tb1.exame_sifilis_hiv_realizado = true THEN 'Identificado'::text
-            WHEN tb1.exame_sifilis_hiv_realizado = false THEN 'Não identificado'::text
+            WHEN tb1.exame_sifilis_hiv_realizado_valido = true THEN 'Identificado'::text
+            WHEN tb1.exame_sifilis_hiv_realizado_valido = false THEN 'Não identificado'::text
             ELSE 'Sem dados'::text
         END AS exame_sifilis_hiv_realizado_identificacao,
     tb1.possui_registro_aborto,


### PR DESCRIPTION
_**Alterações de código das listas nominais**_

**Motivo do ajuste:**
Ao rever as especificações de Notas Técnicas do PB relativas ao período de contabilização de atendimentos e procedimentos de uma gestação, teve-se o entendimento que a regra de cálculo atual estava equivocada. A nova regra foi confirmada com a resposta do Ministério da Saúde, após envio de uma LAI pelo time, e também com os especialistas de saúde da Impulso.

**O que está sendo alterado:**
- A view  `painel_coordenadores_lista_nominal_gestantes.sql` foi ajustada para ler as variáveis corretas


