### PR TITLE
Corrige Dados Demo Viçosa e Impulsolândia

### DIFF
--- a/bd_analitico/esus-backups/impulso_previne_dados_nominais/views_materializadas/lista_nominal_diabeticos_unificada.sql
+++ b/bd_analitico/esus-backups/impulso_previne_dados_nominais/views_materializadas/lista_nominal_diabeticos_unificada.sql
@@ -1,3 +1,4 @@
+-- impulso_previne_dados_nominais.lista_nominal_diabeticos_unificada source
 
 CREATE MATERIALIZED VIEW impulso_previne_dados_nominais.lista_nominal_diabeticos_unificada
 TABLESPACE pg_default
@@ -31,6 +32,6 @@ AS SELECT consulta_tabelas_lista_nominal_diabeticos.municipio_id_sus,
     consulta_tabelas_lista_nominal_diabeticos.se_faleceu,
     consulta_tabelas_lista_nominal_diabeticos.se_mudou,
     consulta_tabelas_lista_nominal_diabeticos.criacao_data,
-    consulta_tabelas_lista_nominal_diabeticos.atualizacao_data
+    now() AS atualizacao_data
    FROM impulso_previne_dados_nominais.consulta_tabelas_lista_nominal_diabeticos() consulta_tabelas_lista_nominal_diabeticos(municipio_id_sus, quadrimestre_atual, realizou_solicitacao_hemoglobina_ultimos_6_meses, dt_solicitacao_hemoglobina_glicada_mais_recente, realizou_consulta_ultimos_6_meses, dt_consulta_mais_recente, co_seq_fat_cidadao_pec, cidadao_cpf, cidadao_cns, cidadao_nome, cidadao_nome_social, cidadao_sexo, dt_nascimento, estabelecimento_cnes_atendimento, estabelecimento_cnes_cadastro, estabelecimento_nome_atendimento, estabelecimento_nome_cadastro, equipe_ine_atendimento, equipe_ine_cadastro, equipe_nome_atendimento, equipe_nome_cadastro, acs_nome_cadastro, acs_nome_visita, possui_diabetes_autoreferida, possui_diabetes_diagnosticada, data_ultimo_cadastro, dt_ultima_consulta, se_faleceu, se_mudou, criacao_data, atualizacao_data)
 WITH DATA;

--- a/bd_analitico/esus-backups/impulso_previne_dados_nominais/views_materializadas/lista_nominal_hipertensos_unificada.sql
+++ b/bd_analitico/esus-backups/impulso_previne_dados_nominais/views_materializadas/lista_nominal_hipertensos_unificada.sql
@@ -1,3 +1,4 @@
+-- impulso_previne_dados_nominais.lista_nominal_hipertensos_unificada source
 
 CREATE MATERIALIZED VIEW impulso_previne_dados_nominais.lista_nominal_hipertensos_unificada
 TABLESPACE pg_default
@@ -31,6 +32,6 @@ AS SELECT consulta_tabelas_lista_nominal_hipertensos.municipio_id_sus,
     consulta_tabelas_lista_nominal_hipertensos.se_faleceu,
     consulta_tabelas_lista_nominal_hipertensos.se_mudou,
     consulta_tabelas_lista_nominal_hipertensos.criacao_data,
-    consulta_tabelas_lista_nominal_hipertensos.atualizacao_data
+    now() AS atualizacao_data
    FROM impulso_previne_dados_nominais.consulta_tabelas_lista_nominal_hipertensos() consulta_tabelas_lista_nominal_hipertensos(municipio_id_sus, quadrimestre_atual, realizou_afericao_ultimos_6_meses, dt_afericao_pressao_mais_recente, realizou_consulta_ultimos_6_meses, dt_consulta_mais_recente, co_seq_fat_cidadao_pec, cidadao_cpf, cidadao_cns, cidadao_nome, cidadao_nome_social, cidadao_sexo, dt_nascimento, estabelecimento_cnes_atendimento, estabelecimento_cnes_cadastro, estabelecimento_nome_atendimento, estabelecimento_nome_cadastro, equipe_ine_atendimento, equipe_ine_cadastro, equipe_nome_atendimento, equipe_nome_cadastro, acs_nome_cadastro, acs_nome_visita, possui_hipertensao_autorreferida, possui_hipertensao_diagnosticada, data_ultimo_cadastro, dt_ultima_consulta, se_faleceu, se_mudou, criacao_data, atualizacao_data)
 WITH DATA;

--- a/bd_analitico/esus-backups/impulso_previne_dados_nominais/views_materializadas/painel_citopatologico_lista_nominal.sql
+++ b/bd_analitico/esus-backups/impulso_previne_dados_nominais/views_materializadas/painel_citopatologico_lista_nominal.sql
@@ -66,7 +66,8 @@ AS WITH dados_anonimizados_demo_vicosa AS (
                     tb1_1.acs_nome_visita,
                     tb1_1.criacao_data
                    FROM impulso_previne_dados_nominais.lista_nominal_citopatologico_unificada tb1_1
-                   where tb1_1.municipio_id_sus::text = '317130'::text) res
+                  WHERE tb1_1.municipio_id_sus::text = '317130'::text
+                  and tb1_1.equipe_ine_ultimo_atendimento is not null and tb1_1.equipe_ine_cadastro is not null ) res
              JOIN configuracoes.nomes_ficticios_citopatologico nomes ON res.seq = nomes.seq
              JOIN configuracoes.nomes_ficticios_gestantes nomes2 ON res.seq = nomes2.seq
         ), dados_anonimizados_impulsolandia AS (
@@ -134,7 +135,8 @@ AS WITH dados_anonimizados_demo_vicosa AS (
                     tb1_1.acs_nome_visita,
                     tb1_1.criacao_data
                    FROM impulso_previne_dados_nominais.lista_nominal_citopatologico_unificada tb1_1
-                   where tb1_1.municipio_id_sus::text = '317130'::text) res
+                  WHERE tb1_1.municipio_id_sus::text = '317130'::text
+                  and tb1_1.equipe_ine_ultimo_atendimento is not null and tb1_1.equipe_ine_cadastro is not null ) res
              JOIN configuracoes.nomes_ficticios_citopatologico nomes ON res.seq = nomes.seq
              JOIN configuracoes.nomes_ficticios_gestantes nomes2 ON res.seq = nomes2.seq
         ), dados_transmissoes_recentes AS (

--- a/bd_analitico/esus-backups/impulso_previne_dados_nominais/views_materializadas/painel_citopatologico_lista_nominal.sql
+++ b/bd_analitico/esus-backups/impulso_previne_dados_nominais/views_materializadas/painel_citopatologico_lista_nominal.sql
@@ -65,7 +65,8 @@ AS WITH dados_anonimizados_demo_vicosa AS (
                     tb1_1.acs_nome_ultimo_atendimento,
                     tb1_1.acs_nome_visita,
                     tb1_1.criacao_data
-                   FROM dados_nominais_mg_vicosa.lista_nominal_citopatologico tb1_1) res
+                   FROM dados_nominais_mg_vicosa.lista_nominal_citopatologico tb1_1
+                   where tb1_1.equipe_ine_cadastro is not null and tb1_1.equipe_ine_ultimo_atendimento is not null) res
              JOIN configuracoes.nomes_ficticios_citopatologico nomes ON res.seq = nomes.seq
              JOIN configuracoes.nomes_ficticios_gestantes nomes2 ON res.seq = nomes2.seq
         ), dados_anonimizados_impulsolandia AS (
@@ -132,7 +133,8 @@ AS WITH dados_anonimizados_demo_vicosa AS (
                     tb1_1.acs_nome_ultimo_atendimento,
                     tb1_1.acs_nome_visita,
                     tb1_1.criacao_data
-                   FROM dados_nominais_mg_vicosa.lista_nominal_citopatologico tb1_1) res
+                   FROM dados_nominais_mg_vicosa.lista_nominal_citopatologico tb1_1
+                   where tb1_1.equipe_ine_cadastro is not null and tb1_1.equipe_ine_ultimo_atendimento is not null ) res
              JOIN configuracoes.nomes_ficticios_citopatologico nomes ON res.seq = nomes.seq
              JOIN configuracoes.nomes_ficticios_gestantes nomes2 ON res.seq = nomes2.seq
         ), dados_transmissoes_recentes AS (
@@ -267,62 +269,73 @@ AS WITH dados_anonimizados_demo_vicosa AS (
             dados_transmissoes_recentes.acs_nome_visita,
             dados_transmissoes_recentes.criacao_data
            FROM dados_transmissoes_recentes
+        ), data_registro_producao AS (
+         SELECT une_as_bases.municipio_id_sus,
+            impulso_previne_dados_nominais.equipe_ine(une_as_bases.municipio_id_sus::text, COALESCE(une_as_bases.equipe_ine_cadastro, une_as_bases.equipe_ine_ultimo_atendimento)::text) AS ine_master,
+            max(GREATEST(une_as_bases.dt_ultimo_exame, une_as_bases.dt_ultimo_atendimento, une_as_bases.dt_ultimo_cadastro)) AS dt_registro_producao_mais_recente,
+            min(LEAST(une_as_bases.dt_ultimo_exame, une_as_bases.dt_ultimo_atendimento, une_as_bases.dt_ultimo_cadastro)) AS dt_registro_producao_mais_antigo
+           FROM une_as_bases
+          GROUP BY une_as_bases.municipio_id_sus, (impulso_previne_dados_nominais.equipe_ine(une_as_bases.municipio_id_sus::text, COALESCE(une_as_bases.equipe_ine_cadastro, une_as_bases.equipe_ine_ultimo_atendimento)::text))
+        ), tabela_aux AS (
+         SELECT tb1.municipio_id_sus,
+            concat(tb2.nome, ' - ', tb2.uf_sigla) AS municipio_uf,
+            tb1.paciente_nome,
+                CASE
+                    WHEN tb1.cidadao_cpf IS NULL THEN to_char(tb1.dt_nascimento::timestamp with time zone, 'DD/MM/YYYY'::text)
+                    ELSE concat("substring"(tb1.cidadao_cpf, 1, 3), '.', "substring"(tb1.cidadao_cpf, 4, 3), '.', "substring"(tb1.cidadao_cpf, 7, 3), '-', "substring"(tb1.cidadao_cpf, 10, 2))
+                END AS cidadao_cpf_dt_nascimento,
+                CASE
+                    WHEN tb1.status_exame::text = ANY (ARRAY['exame_realizado_antes_dos_25'::character varying::text, 'exame_nunca_realizado'::character varying::text]) THEN '-'::text
+                    ELSE to_char(tb1.data_projetada_proximo_exame::timestamp with time zone, 'DD/MM/YYYY'::text)
+                END AS vencimento_da_coleta,
+                CASE
+                    WHEN tb1.status_exame::text = 'exame_em_dia'::text THEN 'Em dia'::text
+                    ELSE to_char(tb1.data_limite_a_realizar_proximo_exame::timestamp with time zone, 'DD/MM/YYYY'::text)
+                END AS prazo_proxima_coleta,
+            tb1.paciente_idade_atual AS idade,
+            COALESCE(tb1.acs_nome_visita, tb1.acs_nome_cadastro) AS acs_nome,
+            COALESCE(tb1.estabelecimento_cnes_cadastro, tb1.estabelecimento_cnes_ultimo_atendimento) AS estabelecimento_cnes,
+            COALESCE(tb1.estabelecimento_nome_cadastro, tb1.estabelecimento_nome_ultimo_atendimento) AS estabelecimento_nome,
+            COALESCE(tb1.equipe_ine_cadastro, tb1.equipe_ine_ultimo_atendimento) AS equipe_ine,
+            impulso_previne_dados_nominais.equipe_ine(tb1.municipio_id_sus::text, COALESCE(tb1.equipe_ine_cadastro, tb1.equipe_ine_ultimo_atendimento)::text) AS ine_master,
+            impulso_previne_dados_nominais.equipe_ine(tb1.municipio_id_sus::text, COALESCE(tb1.equipe_nome_cadastro, tb1.equipe_nome_ultimo_atendimento)::text) AS equipe_nome,
+                CASE
+                    WHEN tb1.status_exame::text = 'exame_em_dia'::text THEN 12
+                    WHEN tb1.status_exame::text = 'exame_nunca_realizado'::text THEN 13
+                    WHEN tb1.status_exame::text = 'exame_realizado_antes_dos_25'::text THEN 14
+                    WHEN tb1.status_exame::text = 'exame_vence_no_quadrimestre_atual'::text THEN 15
+                    WHEN tb1.status_exame::text = 'exame_vencido'::text THEN 16
+                    ELSE NULL::integer
+                END AS id_status_usuario,
+                CASE
+                    WHEN tb1.paciente_idade_atual <= 39 THEN 6
+                    WHEN tb1.paciente_idade_atual >= 40 AND tb1.paciente_idade_atual <= 49 THEN 7
+                    WHEN tb1.paciente_idade_atual >= 50 AND tb1.paciente_idade_atual <= 64 THEN 8
+                    ELSE NULL::integer
+                END AS id_faixa_etaria,
+            tb1.criacao_data,
+            CURRENT_TIMESTAMP AS atualizacao_data
+           FROM une_as_bases tb1
+             LEFT JOIN listas_de_codigos.municipios tb2 ON tb1.municipio_id_sus::bpchar = tb2.id_sus
         )
-, data_registro_producao AS (
-    SELECT 
-        municipio_id_sus,
-        impulso_previne_dados_nominais.equipe_ine(municipio_id_sus::text, COALESCE(equipe_ine_cadastro, equipe_ine_ultimo_atendimento)::text) AS ine_master,
-        MAX(GREATEST(dt_ultimo_exame,dt_ultimo_atendimento,dt_ultimo_cadastro)) AS dt_registro_producao_mais_recente,
-        MIN(LEAST(dt_ultimo_exame,dt_ultimo_atendimento,dt_ultimo_cadastro)) AS dt_registro_producao_mais_antigo
-    FROM une_as_bases
-    GROUP BY 1, 2
-)
-, tabela_aux AS (
- SELECT tb1.municipio_id_sus,
-    concat(tb2.nome, ' - ', tb2.uf_sigla) AS municipio_uf,
-    tb1.paciente_nome,
-        CASE
-            WHEN tb1.cidadao_cpf IS NULL THEN to_char(tb1.dt_nascimento::timestamp with time zone, 'DD/MM/YYYY'::text)
-            ELSE concat("substring"(tb1.cidadao_cpf, 1, 3), '.', "substring"(tb1.cidadao_cpf, 4, 3), '.', "substring"(tb1.cidadao_cpf, 7, 3), '-', "substring"(tb1.cidadao_cpf, 10, 2))
-        END AS cidadao_cpf_dt_nascimento,
-        CASE
-            WHEN tb1.status_exame::text = ANY (ARRAY['exame_realizado_antes_dos_25'::character varying::text, 'exame_nunca_realizado'::character varying::text]) THEN '-'::text
-            ELSE to_char(tb1.data_projetada_proximo_exame::timestamp with time zone, 'DD/MM/YYYY'::text)
-        END AS vencimento_da_coleta,
-        CASE
-            WHEN tb1.status_exame::text = 'exame_em_dia'::text THEN 'Em dia'::text
-            ELSE to_char(tb1.data_limite_a_realizar_proximo_exame::timestamp with time zone, 'DD/MM/YYYY'::text)
-        END AS prazo_proxima_coleta,
-    tb1.paciente_idade_atual AS idade,
-    COALESCE(tb1.acs_nome_visita, tb1.acs_nome_cadastro) AS acs_nome,
-    COALESCE(tb1.estabelecimento_cnes_cadastro, tb1.estabelecimento_cnes_ultimo_atendimento) AS estabelecimento_cnes,
-    COALESCE(tb1.estabelecimento_nome_cadastro, tb1.estabelecimento_nome_ultimo_atendimento) AS estabelecimento_nome,
-    COALESCE(tb1.equipe_ine_cadastro, tb1.equipe_ine_ultimo_atendimento) AS equipe_ine,
-    impulso_previne_dados_nominais.equipe_ine(tb1.municipio_id_sus::text, COALESCE(tb1.equipe_ine_cadastro, tb1.equipe_ine_ultimo_atendimento)::text) AS ine_master,
-    impulso_previne_dados_nominais.equipe_ine(tb1.municipio_id_sus::text, COALESCE(tb1.equipe_nome_cadastro, tb1.equipe_nome_ultimo_atendimento)::text) AS equipe_nome,
-        CASE
-            WHEN tb1.status_exame::text = 'exame_em_dia'::text THEN 12
-            WHEN tb1.status_exame::text = 'exame_nunca_realizado'::text THEN 13
-            WHEN tb1.status_exame::text = 'exame_realizado_antes_dos_25'::text THEN 14
-            WHEN tb1.status_exame::text = 'exame_vence_no_quadrimestre_atual'::text THEN 15
-            WHEN tb1.status_exame::text = 'exame_vencido'::text THEN 16
-            ELSE NULL::integer
-        END AS id_status_usuario,
-        CASE
-            WHEN tb1.paciente_idade_atual <= 39 THEN 6
-            WHEN tb1.paciente_idade_atual >= 40 AND tb1.paciente_idade_atual <= 49 THEN 7
-            WHEN tb1.paciente_idade_atual >= 50 AND tb1.paciente_idade_atual <= 64 THEN 8
-            ELSE NULL::integer
-        END AS id_faixa_etaria,
-    tb1.criacao_data,
-    CURRENT_TIMESTAMP AS atualizacao_data
-   FROM une_as_bases tb1
-     LEFT JOIN listas_de_codigos.municipios tb2 ON tb1.municipio_id_sus::bpchar = tb2.id_sus
-) SELECT
-    tabela_aux.*,
+ SELECT tabela_aux.municipio_id_sus,
+    tabela_aux.municipio_uf,
+    tabela_aux.paciente_nome,
+    tabela_aux.cidadao_cpf_dt_nascimento,
+    tabela_aux.vencimento_da_coleta,
+    tabela_aux.prazo_proxima_coleta,
+    tabela_aux.idade,
+    tabela_aux.acs_nome,
+    tabela_aux.estabelecimento_cnes,
+    tabela_aux.estabelecimento_nome,
+    tabela_aux.equipe_ine,
+    tabela_aux.ine_master,
+    tabela_aux.equipe_nome,
+    tabela_aux.id_status_usuario,
+    tabela_aux.id_faixa_etaria,
+    tabela_aux.criacao_data,
+    tabela_aux.atualizacao_data,
     drp.dt_registro_producao_mais_recente
-FROM tabela_aux
-LEFT JOIN data_registro_producao drp 
-    ON drp.municipio_id_sus = tabela_aux.municipio_id_sus
-    AND drp.ine_master = tabela_aux.ine_master
+   FROM tabela_aux
+     LEFT JOIN data_registro_producao drp ON drp.municipio_id_sus::text = tabela_aux.municipio_id_sus::text AND drp.ine_master = tabela_aux.ine_master
 WITH DATA;

--- a/bd_analitico/esus-backups/impulso_previne_dados_nominais/views_materializadas/painel_citopatologico_lista_nominal.sql
+++ b/bd_analitico/esus-backups/impulso_previne_dados_nominais/views_materializadas/painel_citopatologico_lista_nominal.sql
@@ -67,7 +67,7 @@ AS WITH dados_anonimizados_demo_vicosa AS (
                     tb1_1.acs_nome_visita,
                     tb1_1.criacao_data
                    FROM impulso_previne_dados_nominais.lista_nominal_citopatologico_unificada tb1_1
-                  WHERE tb1_1.municipio_id_sus::text = '317130'::text AND tb1_1.equipe_ine_ultimo_atendimento IS NOT NULL AND tb1_1.equipe_ine_ultimo_atendimento::text <> '-'::text AND tb1_1.equipe_ine_cadastro IS NOT NULL AND tb1_1.equipe_ine_cadastro::text <> '-'::text AND tb1_1.equipe_nome_ultimo_atendimento IS NOT NULL AND (tb1_1.equipe_nome_ultimo_atendimento::text <> ALL (ARRAY['EMAD'::character varying, 'EAPP DE SAUDE VICOSA'::character varying, 'ESF BOM JESUS III'::character varying, 'EMULTI SAO JOSE CIDADE NOVA BA'::character varying, 'EMAD'::character varying, 'EMULTI SAO JOSE DO TRIUNFO'::character varying, 'EMULTI BOM JESUS'::character varying]::text[])) AND tb1_1.equipe_nome_cadastro IS NOT NULL AND tb1_1.equipe_nome_cadastro::text <> 'EMAD'::text) res
+                  WHERE tb1_1.municipio_id_sus::text = '317130'::text AND tb1_1.equipe_ine_ultimo_atendimento IS NOT NULL AND tb1_1.equipe_ine_ultimo_atendimento::text <> '-'::text AND tb1_1.equipe_ine_cadastro IS NOT NULL AND tb1_1.equipe_ine_cadastro::text <> '-'::text AND tb1_1.equipe_nome_ultimo_atendimento IS NOT NULL AND (tb1_1.equipe_nome_ultimo_atendimento::text <> ALL (ARRAY['EMAD'::character varying::text, 'EAPP DE SAUDE VICOSA'::character varying::text, 'ESF BOM JESUS III'::character varying::text, 'EMULTI SAO JOSE CIDADE NOVA BA'::character varying::text, 'EMAD'::character varying::text, 'EMULTI SAO JOSE DO TRIUNFO'::character varying::text, 'EMULTI BOM JESUS'::character varying::text])) AND tb1_1.equipe_nome_cadastro IS NOT NULL AND tb1_1.equipe_nome_cadastro::text <> 'EMAD'::text) res
              LEFT JOIN configuracoes.nomes_ficticios_citopatologico nomes ON res.seq = nomes.seq
              LEFT JOIN configuracoes.nomes_ficticios_hipertensos nomes2 ON res.seq = nomes2.seq
         ), dados_anonimizados_impulsolandia AS (
@@ -135,9 +135,9 @@ AS WITH dados_anonimizados_demo_vicosa AS (
                     tb1_1.acs_nome_visita,
                     tb1_1.criacao_data
                    FROM impulso_previne_dados_nominais.lista_nominal_citopatologico_unificada tb1_1
-                  WHERE tb1_1.municipio_id_sus::text = '317130'::text) res
-             JOIN configuracoes.nomes_ficticios_citopatologico nomes ON res.seq = nomes.seq
-             JOIN configuracoes.nomes_ficticios_gestantes nomes2 ON res.seq = nomes2.seq
+                  WHERE tb1_1.municipio_id_sus::text = '317130'::text AND tb1_1.equipe_ine_ultimo_atendimento IS NOT NULL AND tb1_1.equipe_ine_ultimo_atendimento::text <> '-'::text AND tb1_1.equipe_ine_cadastro IS NOT NULL AND tb1_1.equipe_nome_ultimo_atendimento IS NOT NULL AND (tb1_1.equipe_nome_ultimo_atendimento::text <> ALL (ARRAY['EMAD'::character varying::text, 'EAPP DE SAUDE VICOSA'::character varying::text, 'ESF BOM JESUS III'::character varying::text, 'EMULTI SAO JOSE CIDADE NOVA BA'::character varying::text, 'EMAD'::character varying::text, 'EMULTI SAO JOSE DO TRIUNFO'::character varying::text, 'EMULTI BOM JESUS'::character varying::text])) AND tb1_1.equipe_nome_cadastro IS NOT NULL AND tb1_1.equipe_nome_cadastro::text <> 'EMAD'::text) res
+             LEFT JOIN configuracoes.nomes_ficticios_citopatologico nomes ON res.seq = nomes.seq
+             LEFT JOIN configuracoes.nomes_ficticios_hipertensos nomes2 ON res.seq = nomes2.seq
         ), dados_transmissoes_recentes AS (
          SELECT tb1_1.municipio_id_sus,
             tb1_1.quadrimestre_atual,

--- a/bd_analitico/esus-backups/impulso_previne_dados_nominais/views_materializadas/painel_citopatologico_lista_nominal.sql
+++ b/bd_analitico/esus-backups/impulso_previne_dados_nominais/views_materializadas/painel_citopatologico_lista_nominal.sql
@@ -300,7 +300,7 @@ AS WITH dados_anonimizados_demo_vicosa AS (
             COALESCE(tb1.estabelecimento_nome_cadastro, tb1.estabelecimento_nome_ultimo_atendimento) AS estabelecimento_nome,
             COALESCE(tb1.equipe_ine_cadastro, tb1.equipe_ine_ultimo_atendimento) AS equipe_ine,
             impulso_previne_dados_nominais.equipe_ine(tb1.municipio_id_sus::text, COALESCE(tb1.equipe_ine_cadastro, tb1.equipe_ine_ultimo_atendimento)::text) AS ine_master,
-            impulso_previne_dados_nominais.equipe_ine(tb1.municipio_id_sus::text, COALESCE(tb1.equipe_nome_cadastro, tb1.equipe_nome_ultimo_atendimento)::text) AS equipe_nome,
+            COALESCE(tb1.equipe_nome_cadastro, tb1.equipe_nome_ultimo_atendimento, 'SEM EQUIPE'::character varying) AS equipe_nome,
                 CASE
                     WHEN tb1.status_exame::text = 'exame_em_dia'::text THEN 12
                     WHEN tb1.status_exame::text = 'exame_nunca_realizado'::text THEN 13

--- a/bd_analitico/esus-backups/impulso_previne_dados_nominais/views_materializadas/painel_citopatologico_lista_nominal.sql
+++ b/bd_analitico/esus-backups/impulso_previne_dados_nominais/views_materializadas/painel_citopatologico_lista_nominal.sql
@@ -1,3 +1,4 @@
+-- impulso_previne_dados_nominais.painel_citopatologico_lista_nominal source
 
 CREATE MATERIALIZED VIEW impulso_previne_dados_nominais.painel_citopatologico_lista_nominal
 TABLESPACE pg_default
@@ -66,10 +67,9 @@ AS WITH dados_anonimizados_demo_vicosa AS (
                     tb1_1.acs_nome_visita,
                     tb1_1.criacao_data
                    FROM impulso_previne_dados_nominais.lista_nominal_citopatologico_unificada tb1_1
-                  WHERE tb1_1.municipio_id_sus::text = '317130'::text
-                  and tb1_1.equipe_ine_ultimo_atendimento is not null and tb1_1.equipe_ine_cadastro is not null ) res
-             JOIN configuracoes.nomes_ficticios_citopatologico nomes ON res.seq = nomes.seq
-             JOIN configuracoes.nomes_ficticios_gestantes nomes2 ON res.seq = nomes2.seq
+                  WHERE tb1_1.municipio_id_sus::text = '317130'::text AND tb1_1.equipe_ine_ultimo_atendimento IS NOT NULL AND tb1_1.equipe_ine_ultimo_atendimento::text <> '-'::text AND tb1_1.equipe_ine_cadastro IS NOT NULL AND tb1_1.equipe_ine_cadastro::text <> '-'::text AND tb1_1.equipe_nome_ultimo_atendimento IS NOT NULL AND (tb1_1.equipe_nome_ultimo_atendimento::text <> ALL (ARRAY['EMAD'::character varying, 'EAPP DE SAUDE VICOSA'::character varying, 'ESF BOM JESUS III'::character varying, 'EMULTI SAO JOSE CIDADE NOVA BA'::character varying, 'EMAD'::character varying, 'EMULTI SAO JOSE DO TRIUNFO'::character varying, 'EMULTI BOM JESUS'::character varying]::text[])) AND tb1_1.equipe_nome_cadastro IS NOT NULL AND tb1_1.equipe_nome_cadastro::text <> 'EMAD'::text) res
+             LEFT JOIN configuracoes.nomes_ficticios_citopatologico nomes ON res.seq = nomes.seq
+             LEFT JOIN configuracoes.nomes_ficticios_hipertensos nomes2 ON res.seq = nomes2.seq
         ), dados_anonimizados_impulsolandia AS (
          SELECT '111111'::character varying AS municipio_id_sus,
             res.quadrimestre_atual,
@@ -135,8 +135,7 @@ AS WITH dados_anonimizados_demo_vicosa AS (
                     tb1_1.acs_nome_visita,
                     tb1_1.criacao_data
                    FROM impulso_previne_dados_nominais.lista_nominal_citopatologico_unificada tb1_1
-                  WHERE tb1_1.municipio_id_sus::text = '317130'::text
-                  and tb1_1.equipe_ine_ultimo_atendimento is not null and tb1_1.equipe_ine_cadastro is not null ) res
+                  WHERE tb1_1.municipio_id_sus::text = '317130'::text) res
              JOIN configuracoes.nomes_ficticios_citopatologico nomes ON res.seq = nomes.seq
              JOIN configuracoes.nomes_ficticios_gestantes nomes2 ON res.seq = nomes2.seq
         ), dados_transmissoes_recentes AS (

--- a/bd_analitico/esus-backups/impulso_previne_dados_nominais/views_materializadas/painel_citopatologico_lista_nominal.sql
+++ b/bd_analitico/esus-backups/impulso_previne_dados_nominais/views_materializadas/painel_citopatologico_lista_nominal.sql
@@ -65,8 +65,8 @@ AS WITH dados_anonimizados_demo_vicosa AS (
                     tb1_1.acs_nome_ultimo_atendimento,
                     tb1_1.acs_nome_visita,
                     tb1_1.criacao_data
-                   FROM dados_nominais_mg_vicosa.lista_nominal_citopatologico tb1_1
-                   where tb1_1.equipe_ine_cadastro is not null and tb1_1.equipe_ine_ultimo_atendimento is not null) res
+                   FROM impulso_previne_dados_nominais.lista_nominal_citopatologico_unificada tb1_1
+                   where tb1_1.municipio_id_sus::text = '317130'::text) res
              JOIN configuracoes.nomes_ficticios_citopatologico nomes ON res.seq = nomes.seq
              JOIN configuracoes.nomes_ficticios_gestantes nomes2 ON res.seq = nomes2.seq
         ), dados_anonimizados_impulsolandia AS (
@@ -133,8 +133,8 @@ AS WITH dados_anonimizados_demo_vicosa AS (
                     tb1_1.acs_nome_ultimo_atendimento,
                     tb1_1.acs_nome_visita,
                     tb1_1.criacao_data
-                   FROM dados_nominais_mg_vicosa.lista_nominal_citopatologico tb1_1
-                   where tb1_1.equipe_ine_cadastro is not null and tb1_1.equipe_ine_ultimo_atendimento is not null ) res
+                   FROM impulso_previne_dados_nominais.lista_nominal_citopatologico_unificada tb1_1
+                   where tb1_1.municipio_id_sus::text = '317130'::text) res
              JOIN configuracoes.nomes_ficticios_citopatologico nomes ON res.seq = nomes.seq
              JOIN configuracoes.nomes_ficticios_gestantes nomes2 ON res.seq = nomes2.seq
         ), dados_transmissoes_recentes AS (

--- a/bd_analitico/esus-backups/impulso_previne_dados_nominais/views_materializadas/painel_enfermeiras_lista_nominal_diabeticos.sql
+++ b/bd_analitico/esus-backups/impulso_previne_dados_nominais/views_materializadas/painel_enfermeiras_lista_nominal_diabeticos.sql
@@ -65,7 +65,8 @@ AS WITH dados_anonimizados_demo_vicosa AS (
                     tb1_1.criacao_data,
                     tb1_1.atualizacao_data
                    FROM impulso_previne_dados_nominais.lista_nominal_diabeticos_unificada tb1_1
-                   where tb1_1.municipio_id_sus::text = '317130'::text) res
+                  WHERE tb1_1.municipio_id_sus::text = '317130'::text
+                  and tb1_1.equipe_ine_atendimento is not null and tb1_1.equipe_ine_cadastro is not null) res
              JOIN configuracoes.nomes_ficticios_diabeticos nomes ON res.seq = nomes.seq
              JOIN configuracoes.nomes_ficticios_hipertensos nomes2 ON res.seq = nomes2.seq
         ), dados_anonimizados_impulsolandia AS (
@@ -132,7 +133,8 @@ AS WITH dados_anonimizados_demo_vicosa AS (
                     tb1_1.criacao_data,
                     tb1_1.atualizacao_data
                    FROM impulso_previne_dados_nominais.lista_nominal_diabeticos_unificada tb1_1
-                   where tb1_1.municipio_id_sus::text = '317130'::text) res
+                  WHERE tb1_1.municipio_id_sus::text = '317130'::text
+                  and tb1_1.equipe_ine_atendimento is not null and tb1_1.equipe_ine_cadastro is not null) res
              JOIN configuracoes.nomes_ficticios_diabeticos nomes ON res.seq = nomes.seq
              JOIN configuracoes.nomes_ficticios_hipertensos nomes2 ON res.seq = nomes2.seq
         ), dados_transmissoes_recentes AS (
@@ -175,7 +177,7 @@ AS WITH dados_anonimizados_demo_vicosa AS (
             dados_anonimizados_demo_vicosa.dt_solicitacao_hemoglobina_glicada_mais_recente,
             dados_anonimizados_demo_vicosa.realizou_consulta_ultimos_6_meses,
             dados_anonimizados_demo_vicosa.dt_consulta_mais_recente,
-            dados_anonimizados_demo_vicosa.co_seq_fat_cidadao_pec::text AS co_seq_fat_cidadao_pec,
+            dados_anonimizados_demo_vicosa.co_seq_fat_cidadao_pec,
             dados_anonimizados_demo_vicosa.cidadao_cpf,
             dados_anonimizados_demo_vicosa.cidadao_cns,
             dados_anonimizados_demo_vicosa.cidadao_nome,
@@ -207,7 +209,7 @@ AS WITH dados_anonimizados_demo_vicosa AS (
             dados_anonimizados_impulsolandia.dt_solicitacao_hemoglobina_glicada_mais_recente,
             dados_anonimizados_impulsolandia.realizou_consulta_ultimos_6_meses,
             dados_anonimizados_impulsolandia.dt_consulta_mais_recente,
-            dados_anonimizados_impulsolandia.co_seq_fat_cidadao_pec::text AS co_seq_fat_cidadao_pec,
+            dados_anonimizados_impulsolandia.co_seq_fat_cidadao_pec,
             dados_anonimizados_impulsolandia.cidadao_cpf,
             dados_anonimizados_impulsolandia.cidadao_cns,
             dados_anonimizados_impulsolandia.cidadao_nome,

--- a/bd_analitico/esus-backups/impulso_previne_dados_nominais/views_materializadas/painel_enfermeiras_lista_nominal_diabeticos.sql
+++ b/bd_analitico/esus-backups/impulso_previne_dados_nominais/views_materializadas/painel_enfermeiras_lista_nominal_diabeticos.sql
@@ -64,7 +64,8 @@ AS WITH dados_anonimizados_demo_vicosa AS (
                     tb1_1.se_mudou,
                     tb1_1.criacao_data,
                     tb1_1.atualizacao_data
-                   FROM dados_nominais_mg_vicosa.lista_nominal_diabeticos tb1_1) res
+                   FROM dados_nominais_mg_vicosa.lista_nominal_diabeticos tb1_1
+                  where tb1_1.equipe_ine_atendimento is not null and tb1_1.equipe_ine_cadastro is not null) res
              JOIN configuracoes.nomes_ficticios_diabeticos nomes ON res.seq = nomes.seq
              JOIN configuracoes.nomes_ficticios_hipertensos nomes2 ON res.seq = nomes2.seq
         ), dados_anonimizados_impulsolandia AS (
@@ -130,7 +131,8 @@ AS WITH dados_anonimizados_demo_vicosa AS (
                     tb1_1.se_mudou,
                     tb1_1.criacao_data,
                     tb1_1.atualizacao_data
-                   FROM dados_nominais_mg_vicosa.lista_nominal_diabeticos tb1_1) res
+                   FROM dados_nominais_mg_vicosa.lista_nominal_diabeticos tb1_1
+                   where tb1_1.equipe_ine_atendimento is not null and tb1_1.equipe_ine_cadastro is not null) res
              JOIN configuracoes.nomes_ficticios_diabeticos nomes ON res.seq = nomes.seq
              JOIN configuracoes.nomes_ficticios_hipertensos nomes2 ON res.seq = nomes2.seq
         ), dados_transmissoes_recentes AS (
@@ -262,109 +264,144 @@ AS WITH dados_anonimizados_demo_vicosa AS (
             dados_transmissoes_recentes.se_mudou,
             dados_transmissoes_recentes.criacao_data
            FROM dados_transmissoes_recentes
+        ), data_registro_producao AS (
+         SELECT une_as_bases.municipio_id_sus,
+            impulso_previne_dados_nominais.equipe_ine(une_as_bases.municipio_id_sus::text, COALESCE(une_as_bases.equipe_ine_cadastro, une_as_bases.equipe_ine_atendimento)) AS equipe_ine_cadastro,
+            max(GREATEST(une_as_bases.dt_solicitacao_hemoglobina_glicada_mais_recente::date, une_as_bases.dt_consulta_mais_recente, une_as_bases.data_ultimo_cadastro, une_as_bases.dt_ultima_consulta)) AS dt_registro_producao_mais_recente,
+            min(LEAST(une_as_bases.dt_solicitacao_hemoglobina_glicada_mais_recente::date, une_as_bases.dt_consulta_mais_recente, une_as_bases.data_ultimo_cadastro, une_as_bases.dt_ultima_consulta)) AS dt_registro_producao_mais_antigo
+           FROM une_as_bases
+          GROUP BY une_as_bases.municipio_id_sus, (impulso_previne_dados_nominais.equipe_ine(une_as_bases.municipio_id_sus::text, COALESCE(une_as_bases.equipe_ine_cadastro, une_as_bases.equipe_ine_atendimento)))
+        ), tabela_aux AS (
+         SELECT tb1.municipio_id_sus,
+            concat(tb2.nome, ' - ', tb2.uf_sigla) AS municipio_uf,
+            tb1.quadrimestre_atual,
+            tb1.realizou_solicitacao_hemoglobina_ultimos_6_meses,
+            tb1.dt_solicitacao_hemoglobina_glicada_mais_recente,
+            tb1.realizou_consulta_ultimos_6_meses,
+            tb1.dt_consulta_mais_recente,
+                CASE
+                    WHEN tb1.realizou_solicitacao_hemoglobina_ultimos_6_meses THEN 'Em dia'::text
+                    ELSE impulso_previne_dados_nominais.prazo_proximo_dia()
+                END AS prazo_proxima_solicitacao_hemoglobina,
+                CASE
+                    WHEN tb1.realizou_consulta_ultimos_6_meses THEN 'Em dia'::text
+                    ELSE impulso_previne_dados_nominais.prazo_proximo_dia()
+                END AS prazo_proxima_consulta,
+                CASE
+                    WHEN tb1.realizou_solicitacao_hemoglobina_ultimos_6_meses AND tb1.realizou_consulta_ultimos_6_meses THEN 1
+                    ELSE 0
+                END AS consulta_e_solicitacao_hemoglobina_em_dia,
+                CASE
+                    WHEN tb1.realizou_consulta_ultimos_6_meses IS FALSE OR tb1.realizou_solicitacao_hemoglobina_ultimos_6_meses IS FALSE THEN 'Não está em dia'::text
+                    WHEN tb1.realizou_consulta_ultimos_6_meses AND tb1.realizou_solicitacao_hemoglobina_ultimos_6_meses THEN 'Em dia'::text
+                    ELSE NULL::text
+                END AS status_em_dia,
+                CASE
+                    WHEN tb1.realizou_solicitacao_hemoglobina_ultimos_6_meses AND tb1.realizou_consulta_ultimos_6_meses THEN 'Em dia com consulta e solicitação de hemoglobina'::text
+                    WHEN tb1.realizou_solicitacao_hemoglobina_ultimos_6_meses IS FALSE AND tb1.realizou_consulta_ultimos_6_meses IS FALSE THEN 'Nada em dia'::text
+                    WHEN tb1.realizou_solicitacao_hemoglobina_ultimos_6_meses AND tb1.realizou_consulta_ultimos_6_meses IS FALSE THEN 'Apenas solicitação de hemoglobina em dia'::text
+                    WHEN tb1.realizou_solicitacao_hemoglobina_ultimos_6_meses IS FALSE AND tb1.realizou_consulta_ultimos_6_meses THEN 'Apenas consulta em dia'::text
+                    ELSE NULL::text
+                END AS status_usuario,
+                CASE
+                    WHEN tb1.possui_diabetes_diagnosticada THEN 'Diagnóstico Clínico'::text
+                    WHEN tb1.possui_diabetes_autoreferida AND tb1.possui_diabetes_diagnosticada IS FALSE THEN 'Autorreferida'::text
+                    WHEN tb1.possui_diabetes_autoreferida AND tb1.possui_diabetes_diagnosticada IS NULL THEN 'Autorreferida'::text
+                    ELSE NULL::text
+                END AS identificacao_condicao_diabetes,
+            tb1.cidadao_cpf,
+                CASE
+                    WHEN tb1.cidadao_cpf IS NULL THEN tb1.dt_nascimento::text::character varying::text
+                    ELSE tb1.cidadao_cpf
+                END AS cidadao_cpf_dt_nascimento,
+            tb1.cidadao_cns,
+            tb1.cidadao_nome,
+            tb1.cidadao_nome_social,
+            tb1.cidadao_sexo,
+            tb1.dt_nascimento,
+            date_part('year'::text, age(CURRENT_DATE::timestamp with time zone, tb1.dt_nascimento::timestamp with time zone))::integer AS cidadao_idade,
+                CASE
+                    WHEN date_part('year'::text, age(CURRENT_DATE::timestamp with time zone, tb1.dt_nascimento::timestamp with time zone)) <= 40::double precision THEN '0 a 40 anos'::text
+                    WHEN date_part('year'::text, age(CURRENT_DATE::timestamp with time zone, tb1.dt_nascimento::timestamp with time zone)) > 40::double precision AND date_part('year'::text, age(CURRENT_DATE::timestamp with time zone, tb1.dt_nascimento::timestamp with time zone)) <= 49::double precision THEN '41 a 49 anos'::text
+                    WHEN date_part('year'::text, age(CURRENT_DATE::timestamp with time zone, tb1.dt_nascimento::timestamp with time zone)) > 49::double precision AND date_part('year'::text, age(CURRENT_DATE::timestamp with time zone, tb1.dt_nascimento::timestamp with time zone)) <= 59::double precision THEN '50 a 59 anos'::text
+                    WHEN date_part('year'::text, age(CURRENT_DATE::timestamp with time zone, tb1.dt_nascimento::timestamp with time zone)) > 59::double precision AND date_part('year'::text, age(CURRENT_DATE::timestamp with time zone, tb1.dt_nascimento::timestamp with time zone)) <= 70::double precision THEN '60 a 70 anos'::text
+                    WHEN tb1.dt_nascimento IS NULL THEN NULL::text
+                    ELSE '70 anos ou mais'::text
+                END AS cidadao_faixa_etaria,
+            tb1.estabelecimento_cnes_atendimento,
+            tb1.estabelecimento_cnes_cadastro,
+            tb1.estabelecimento_nome_atendimento,
+            tb1.estabelecimento_nome_cadastro,
+            tb1.equipe_ine_atendimento,
+            impulso_previne_dados_nominais.equipe_ine(tb1.municipio_id_sus::text, COALESCE(tb1.equipe_ine_cadastro, tb1.equipe_ine_atendimento)) AS equipe_ine_cadastro,
+            tb1.equipe_nome_atendimento,
+            impulso_previne_dados_nominais.equipe_ine(tb1.municipio_id_sus::text, COALESCE(tb1.equipe_nome_cadastro, tb1.equipe_nome_atendimento)) AS equipe_nome_cadastro,
+            tb1.acs_nome_cadastro,
+            tb1.acs_nome_visita,
+            tb1.possui_diabetes_autoreferida AS possui_diabetes_autorreferida,
+            tb1.possui_diabetes_diagnosticada,
+                CASE
+                    WHEN tb1.possui_diabetes_autoreferida AND tb1.possui_diabetes_diagnosticada IS FALSE THEN 1
+                    WHEN tb1.possui_diabetes_autoreferida AND tb1.possui_diabetes_diagnosticada IS NULL THEN 1
+                    ELSE 0
+                END AS apenas_autorreferida,
+                CASE
+                    WHEN tb1.possui_diabetes_diagnosticada THEN 1
+                    ELSE 0
+                END AS diagnostico_clinico,
+            tb1.data_ultimo_cadastro,
+            tb1.dt_ultima_consulta,
+            tb1.se_faleceu,
+            tb1.se_mudou,
+            tb1.criacao_data,
+            CURRENT_TIMESTAMP AS atualizacao_data
+           FROM une_as_bases tb1
+             LEFT JOIN listas_de_codigos.municipios tb2 ON tb1.municipio_id_sus::bpchar = tb2.id_sus
+          WHERE COALESCE(tb1.se_faleceu, 0) <> 1
         )
-, data_registro_producao AS (
-    SELECT 
-        municipio_id_sus,
-    	impulso_previne_dados_nominais.equipe_ine(municipio_id_sus::text, COALESCE(equipe_ine_cadastro, equipe_ine_atendimento)) AS equipe_ine_cadastro,
-        MAX(GREATEST(dt_solicitacao_hemoglobina_glicada_mais_recente::date,dt_consulta_mais_recente::date,data_ultimo_cadastro::date,dt_ultima_consulta::date)) AS dt_registro_producao_mais_recente,
-        MIN(LEAST(dt_solicitacao_hemoglobina_glicada_mais_recente::date,dt_consulta_mais_recente::date,data_ultimo_cadastro::date,dt_ultima_consulta::date)) AS dt_registro_producao_mais_antigo
-    FROM une_as_bases
-    GROUP BY 1, 2
-)
-, tabela_aux as (          
- SELECT tb1.municipio_id_sus,
-    concat(tb2.nome, ' - ', tb2.uf_sigla) AS municipio_uf,
-    tb1.quadrimestre_atual,
-    tb1.realizou_solicitacao_hemoglobina_ultimos_6_meses,
-    tb1.dt_solicitacao_hemoglobina_glicada_mais_recente,
-    tb1.realizou_consulta_ultimos_6_meses,
-    tb1.dt_consulta_mais_recente,
-        CASE
-            WHEN tb1.realizou_solicitacao_hemoglobina_ultimos_6_meses THEN 'Em dia'::text
-            ELSE impulso_previne_dados_nominais.prazo_proximo_dia()
-        END AS prazo_proxima_solicitacao_hemoglobina,
-        CASE
-            WHEN tb1.realizou_consulta_ultimos_6_meses THEN 'Em dia'::text
-            ELSE impulso_previne_dados_nominais.prazo_proximo_dia()
-        END AS prazo_proxima_consulta,
-        CASE
-            WHEN tb1.realizou_solicitacao_hemoglobina_ultimos_6_meses AND tb1.realizou_consulta_ultimos_6_meses THEN 1
-            ELSE 0
-        END AS consulta_e_solicitacao_hemoglobina_em_dia,
-        CASE
-            WHEN tb1.realizou_consulta_ultimos_6_meses IS FALSE OR tb1.realizou_solicitacao_hemoglobina_ultimos_6_meses IS FALSE THEN 'Não está em dia'::text
-            WHEN tb1.realizou_consulta_ultimos_6_meses AND tb1.realizou_solicitacao_hemoglobina_ultimos_6_meses THEN 'Em dia'::text
-            ELSE NULL::text
-        END AS status_em_dia,
-        CASE
-            WHEN tb1.realizou_solicitacao_hemoglobina_ultimos_6_meses AND tb1.realizou_consulta_ultimos_6_meses THEN 'Em dia com consulta e solicitação de hemoglobina'::text
-            WHEN tb1.realizou_solicitacao_hemoglobina_ultimos_6_meses IS FALSE AND tb1.realizou_consulta_ultimos_6_meses IS FALSE THEN 'Nada em dia'::text
-            WHEN tb1.realizou_solicitacao_hemoglobina_ultimos_6_meses AND tb1.realizou_consulta_ultimos_6_meses IS FALSE THEN 'Apenas solicitação de hemoglobina em dia'::text
-            WHEN tb1.realizou_solicitacao_hemoglobina_ultimos_6_meses IS FALSE AND tb1.realizou_consulta_ultimos_6_meses THEN 'Apenas consulta em dia'::text
-            ELSE NULL::text
-        END AS status_usuario,
-        CASE
-            WHEN tb1.possui_diabetes_diagnosticada THEN 'Diagnóstico Clínico'::text
-            WHEN tb1.possui_diabetes_autoreferida AND tb1.possui_diabetes_diagnosticada IS FALSE THEN 'Autorreferida'::text
-            WHEN tb1.possui_diabetes_autoreferida AND tb1.possui_diabetes_diagnosticada IS NULL THEN 'Autorreferida'::text
-            ELSE NULL::text
-        END AS identificacao_condicao_diabetes,
-    tb1.cidadao_cpf,
-        CASE
-            WHEN tb1.cidadao_cpf IS NULL THEN tb1.dt_nascimento::text::character varying::text
-            ELSE tb1.cidadao_cpf
-        END AS cidadao_cpf_dt_nascimento,
-    tb1.cidadao_cns,
-    tb1.cidadao_nome,
-    tb1.cidadao_nome_social,
-    tb1.cidadao_sexo,
-    tb1.dt_nascimento,
-    date_part('year'::text, age(CURRENT_DATE::timestamp with time zone, tb1.dt_nascimento::timestamp with time zone))::integer AS cidadao_idade,
-        CASE
-            WHEN date_part('year'::text, age(CURRENT_DATE::timestamp with time zone, tb1.dt_nascimento::timestamp with time zone)) <= 40::double precision THEN '0 a 40 anos'::text
-            WHEN date_part('year'::text, age(CURRENT_DATE::timestamp with time zone, tb1.dt_nascimento::timestamp with time zone)) > 40::double precision AND date_part('year'::text, age(CURRENT_DATE::timestamp with time zone, tb1.dt_nascimento::timestamp with time zone)) <= 49::double precision THEN '41 a 49 anos'::text
-            WHEN date_part('year'::text, age(CURRENT_DATE::timestamp with time zone, tb1.dt_nascimento::timestamp with time zone)) > 49::double precision AND date_part('year'::text, age(CURRENT_DATE::timestamp with time zone, tb1.dt_nascimento::timestamp with time zone)) <= 59::double precision THEN '50 a 59 anos'::text
-            WHEN date_part('year'::text, age(CURRENT_DATE::timestamp with time zone, tb1.dt_nascimento::timestamp with time zone)) > 59::double precision AND date_part('year'::text, age(CURRENT_DATE::timestamp with time zone, tb1.dt_nascimento::timestamp with time zone)) <= 70::double precision THEN '60 a 70 anos'::text
-            WHEN tb1.dt_nascimento IS NULL THEN NULL::text
-            ELSE '70 anos ou mais'::text
-        END AS cidadao_faixa_etaria,
-    tb1.estabelecimento_cnes_atendimento,
-    tb1.estabelecimento_cnes_cadastro,
-    tb1.estabelecimento_nome_atendimento,
-    tb1.estabelecimento_nome_cadastro,
-    tb1.equipe_ine_atendimento,
-    impulso_previne_dados_nominais.equipe_ine(tb1.municipio_id_sus::text, COALESCE(tb1.equipe_ine_cadastro, tb1.equipe_ine_atendimento)) AS equipe_ine_cadastro,
-    tb1.equipe_nome_atendimento,
-    impulso_previne_dados_nominais.equipe_ine(tb1.municipio_id_sus::text, COALESCE(tb1.equipe_nome_cadastro, tb1.equipe_nome_atendimento)) AS equipe_nome_cadastro,
-    tb1.acs_nome_cadastro,
-    tb1.acs_nome_visita,
-    tb1.possui_diabetes_autoreferida AS possui_diabetes_autorreferida,
-    tb1.possui_diabetes_diagnosticada,
-        CASE
-            WHEN tb1.possui_diabetes_autoreferida AND tb1.possui_diabetes_diagnosticada IS FALSE THEN 1
-            WHEN tb1.possui_diabetes_autoreferida AND tb1.possui_diabetes_diagnosticada IS NULL THEN 1
-            ELSE 0
-        END AS apenas_autorreferida,
-        CASE
-            WHEN tb1.possui_diabetes_diagnosticada THEN 1
-            ELSE 0
-        END AS diagnostico_clinico,
-    tb1.data_ultimo_cadastro,
-    tb1.dt_ultima_consulta,
-    tb1.se_faleceu,
-    tb1.se_mudou,
-    tb1.criacao_data,
-    CURRENT_TIMESTAMP AS atualizacao_data
-   FROM une_as_bases tb1
-     LEFT JOIN listas_de_codigos.municipios tb2 ON tb1.municipio_id_sus::bpchar = tb2.id_sus
-  WHERE COALESCE(tb1.se_faleceu, 0) <> 1
-  )
-SELECT
-    tabela_aux.*,
+ SELECT tabela_aux.municipio_id_sus,
+    tabela_aux.municipio_uf,
+    tabela_aux.quadrimestre_atual,
+    tabela_aux.realizou_solicitacao_hemoglobina_ultimos_6_meses,
+    tabela_aux.dt_solicitacao_hemoglobina_glicada_mais_recente,
+    tabela_aux.realizou_consulta_ultimos_6_meses,
+    tabela_aux.dt_consulta_mais_recente,
+    tabela_aux.prazo_proxima_solicitacao_hemoglobina,
+    tabela_aux.prazo_proxima_consulta,
+    tabela_aux.consulta_e_solicitacao_hemoglobina_em_dia,
+    tabela_aux.status_em_dia,
+    tabela_aux.status_usuario,
+    tabela_aux.identificacao_condicao_diabetes,
+    tabela_aux.cidadao_cpf,
+    tabela_aux.cidadao_cpf_dt_nascimento,
+    tabela_aux.cidadao_cns,
+    tabela_aux.cidadao_nome,
+    tabela_aux.cidadao_nome_social,
+    tabela_aux.cidadao_sexo,
+    tabela_aux.dt_nascimento,
+    tabela_aux.cidadao_idade,
+    tabela_aux.cidadao_faixa_etaria,
+    tabela_aux.estabelecimento_cnes_atendimento,
+    tabela_aux.estabelecimento_cnes_cadastro,
+    tabela_aux.estabelecimento_nome_atendimento,
+    tabela_aux.estabelecimento_nome_cadastro,
+    tabela_aux.equipe_ine_atendimento,
+    tabela_aux.equipe_ine_cadastro,
+    tabela_aux.equipe_nome_atendimento,
+    tabela_aux.equipe_nome_cadastro,
+    tabela_aux.acs_nome_cadastro,
+    tabela_aux.acs_nome_visita,
+    tabela_aux.possui_diabetes_autorreferida,
+    tabela_aux.possui_diabetes_diagnosticada,
+    tabela_aux.apenas_autorreferida,
+    tabela_aux.diagnostico_clinico,
+    tabela_aux.data_ultimo_cadastro,
+    tabela_aux.dt_ultima_consulta,
+    tabela_aux.se_faleceu,
+    tabela_aux.se_mudou,
+    tabela_aux.criacao_data,
+    tabela_aux.atualizacao_data,
     drp.dt_registro_producao_mais_recente
-FROM tabela_aux
-LEFT JOIN data_registro_producao drp 
-    ON drp.municipio_id_sus = tabela_aux.municipio_id_sus
-    AND drp.equipe_ine_cadastro = tabela_aux.equipe_ine_cadastro
+   FROM tabela_aux
+     LEFT JOIN data_registro_producao drp ON drp.municipio_id_sus::text = tabela_aux.municipio_id_sus::text AND drp.equipe_ine_cadastro = tabela_aux.equipe_ine_cadastro
 WITH DATA;

--- a/bd_analitico/esus-backups/impulso_previne_dados_nominais/views_materializadas/painel_enfermeiras_lista_nominal_diabeticos.sql
+++ b/bd_analitico/esus-backups/impulso_previne_dados_nominais/views_materializadas/painel_enfermeiras_lista_nominal_diabeticos.sql
@@ -64,8 +64,8 @@ AS WITH dados_anonimizados_demo_vicosa AS (
                     tb1_1.se_mudou,
                     tb1_1.criacao_data,
                     tb1_1.atualizacao_data
-                   FROM dados_nominais_mg_vicosa.lista_nominal_diabeticos tb1_1
-                  where tb1_1.equipe_ine_atendimento is not null and tb1_1.equipe_ine_cadastro is not null) res
+                   FROM impulso_previne_dados_nominais.lista_nominal_diabeticos_unificada tb1_1
+                   where tb1_1.municipio_id_sus::text = '317130'::text) res
              JOIN configuracoes.nomes_ficticios_diabeticos nomes ON res.seq = nomes.seq
              JOIN configuracoes.nomes_ficticios_hipertensos nomes2 ON res.seq = nomes2.seq
         ), dados_anonimizados_impulsolandia AS (
@@ -131,8 +131,8 @@ AS WITH dados_anonimizados_demo_vicosa AS (
                     tb1_1.se_mudou,
                     tb1_1.criacao_data,
                     tb1_1.atualizacao_data
-                   FROM dados_nominais_mg_vicosa.lista_nominal_diabeticos tb1_1
-                   where tb1_1.equipe_ine_atendimento is not null and tb1_1.equipe_ine_cadastro is not null) res
+                   FROM impulso_previne_dados_nominais.lista_nominal_diabeticos_unificada tb1_1
+                   where tb1_1.municipio_id_sus::text = '317130'::text) res
              JOIN configuracoes.nomes_ficticios_diabeticos nomes ON res.seq = nomes.seq
              JOIN configuracoes.nomes_ficticios_hipertensos nomes2 ON res.seq = nomes2.seq
         ), dados_transmissoes_recentes AS (

--- a/bd_analitico/esus-backups/impulso_previne_dados_nominais/views_materializadas/painel_enfermeiras_lista_nominal_hipertensos.sql
+++ b/bd_analitico/esus-backups/impulso_previne_dados_nominais/views_materializadas/painel_enfermeiras_lista_nominal_hipertensos.sql
@@ -64,7 +64,8 @@ AS WITH dados_anonimizados_demo_vicosa AS (
                     tb1_1.se_mudou,
                     tb1_1.criacao_data
                    FROM impulso_previne_dados_nominais.lista_nominal_hipertensos_unificada tb1_1
-                   where tb1_1.municipio_id_sus::text = '317130'::text) res
+                   where tb1_1.municipio_id_sus::text = '317130'::text
+                   and tb1_1.equipe_ine_atendimento is not null and tb1_1.equipe_ine_cadastro is not null) res
              JOIN configuracoes.nomes_ficticios_hipertensos nomes ON res.seq = nomes.seq
              JOIN configuracoes.nomes_ficticios_diabeticos nomes2 ON res.seq = nomes2.seq
         ), dados_anonimizados_impulsolandia AS (
@@ -130,7 +131,8 @@ AS WITH dados_anonimizados_demo_vicosa AS (
                     tb1_1.se_mudou,
                     tb1_1.criacao_data
                    FROM impulso_previne_dados_nominais.lista_nominal_hipertensos_unificada tb1_1
-                   where tb1_1.municipio_id_sus::text = '317130'::text) res
+                   where tb1_1.municipio_id_sus::text = '317130'::text
+                   and tb1_1.equipe_ine_atendimento is not null and tb1_1.equipe_ine_cadastro is not null) res
              JOIN configuracoes.nomes_ficticios_hipertensos nomes ON res.seq = nomes.seq
              JOIN configuracoes.nomes_ficticios_diabeticos nomes2 ON res.seq = nomes2.seq
         ), dados_transmissoes_recentes AS (

--- a/bd_analitico/esus-backups/impulso_previne_dados_nominais/views_materializadas/painel_enfermeiras_lista_nominal_hipertensos.sql
+++ b/bd_analitico/esus-backups/impulso_previne_dados_nominais/views_materializadas/painel_enfermeiras_lista_nominal_hipertensos.sql
@@ -63,8 +63,8 @@ AS WITH dados_anonimizados_demo_vicosa AS (
                     tb1_1.se_faleceu,
                     tb1_1.se_mudou,
                     tb1_1.criacao_data
-                   FROM dados_nominais_mg_vicosa.lista_nominal_hipertensos tb1_1
-                    where tb1_1.equipe_ine_atendimento is not null and tb1_1.equipe_ine_cadastro is not null) res
+                   FROM impulso_previne_dados_nominais.lista_nominal_hipertensos_unificada tb1_1
+                   where tb1_1.municipio_id_sus::text = '317130'::text) res
              JOIN configuracoes.nomes_ficticios_hipertensos nomes ON res.seq = nomes.seq
              JOIN configuracoes.nomes_ficticios_diabeticos nomes2 ON res.seq = nomes2.seq
         ), dados_anonimizados_impulsolandia AS (
@@ -129,8 +129,8 @@ AS WITH dados_anonimizados_demo_vicosa AS (
                     tb1_1.se_faleceu,
                     tb1_1.se_mudou,
                     tb1_1.criacao_data
-                   FROM dados_nominais_mg_vicosa.lista_nominal_hipertensos tb1_1
-                    where tb1_1.equipe_ine_atendimento is not null and tb1_1.equipe_ine_cadastro is not null) res
+                   FROM impulso_previne_dados_nominais.lista_nominal_hipertensos_unificada tb1_1
+                   where tb1_1.municipio_id_sus::text = '317130'::text) res
              JOIN configuracoes.nomes_ficticios_hipertensos nomes ON res.seq = nomes.seq
              JOIN configuracoes.nomes_ficticios_diabeticos nomes2 ON res.seq = nomes2.seq
         ), dados_transmissoes_recentes AS (

--- a/bd_analitico/esus-backups/impulso_previne_dados_nominais/views_materializadas/painel_gestantes_lista_nominal.sql
+++ b/bd_analitico/esus-backups/impulso_previne_dados_nominais/views_materializadas/painel_gestantes_lista_nominal.sql
@@ -301,10 +301,10 @@ AS WITH dados_anonimizados_demo_vicosa AS (
                     ELSE NULL::integer
                 END AS id_exame_hiv_sifilis,
                 CASE
-                    WHEN tb1.possui_registro_aborto = 'Sim'::text THEN 10
-                    WHEN tb1.gestacao_data_dpp > CURRENT_DATE THEN 8
-                    WHEN tb1.gestacao_data_dpp <= CURRENT_DATE THEN 9
-                    WHEN tb1.gestacao_data_dpp IS NULL THEN 11
+                    WHEN tb1.possui_registro_aborto = 'Sim'::text THEN 10 -- Gestantes com registro de aborto
+                    WHEN tb1.gestacao_data_dpp > CURRENT_DATE THEN 8 -- Gestantes ativas
+                    WHEN tb1.gestacao_data_dpp <= CURRENT_DATE THEN 9 -- Gestantes encerradas
+                    WHEN tb1.gestacao_data_dpp IS NULL THEN 11 -- Gestantes sem DUM 
                     ELSE NULL::integer
                 END AS id_status_usuario,
                 CASE

--- a/bd_analitico/esus-backups/impulso_previne_dados_nominais/views_materializadas/painel_gestantes_lista_nominal.sql
+++ b/bd_analitico/esus-backups/impulso_previne_dados_nominais/views_materializadas/painel_gestantes_lista_nominal.sql
@@ -268,43 +268,79 @@ AS WITH dados_anonimizados_demo_vicosa AS (
             COALESCE(tb1.gestante_documento_cpf, tb1.gestante_data_de_nascimento::text) AS cidadao_cpf_dt_nascimento,
             tb1.gestacao_data_dpp,
                 CASE
-                    WHEN date_part('month'::text, tb1.gestacao_data_dpp) >= 1::double precision AND date_part('month'::text, tb1.gestacao_data_dpp) <= 4::double precision THEN concat(date_part('year'::text, tb1.gestacao_data_dpp), '.Q1')
-                    WHEN date_part('month'::text, tb1.gestacao_data_dpp) >= 5::double precision AND date_part('month'::text, tb1.gestacao_data_dpp) <= 8::double precision THEN concat(date_part('year'::text, tb1.gestacao_data_dpp), '.Q2')
-                    WHEN date_part('month'::text, tb1.gestacao_data_dpp) >= 9::double precision AND date_part('month'::text, tb1.gestacao_data_dpp) <= 12::double precision THEN concat(date_part('year'::text, tb1.gestacao_data_dpp), '.Q3')
-                    ELSE 'sem DUM'::text
+                    WHEN date_part('month', tb1.gestacao_data_dpp) >= 1 AND date_part('month', tb1.gestacao_data_dpp) <= 4 THEN concat(date_part('year', tb1.gestacao_data_dpp), '.Q1')
+                    WHEN date_part('month', tb1.gestacao_data_dpp) >= 5 AND date_part('month', tb1.gestacao_data_dpp) <= 8 THEN concat(date_part('year', tb1.gestacao_data_dpp), '.Q2')
+                    WHEN date_part('month', tb1.gestacao_data_dpp) >= 9 AND date_part('month', tb1.gestacao_data_dpp) <= 12 THEN concat(date_part('year', tb1.gestacao_data_dpp), '.Q3')
+                    ELSE 'sem DUM'
                 END AS gestacao_quadrimestre,
                 CASE
-                    WHEN tb1.gestacao_data_dum IS NULL THEN NULL::integer
+                    WHEN tb1.gestacao_data_dum IS NULL 
+                        OR tb1.gestacao_data_dpp < (CASE -- Ou DPP é menor que a data de início do quadrimestre anterior
+                            WHEN date_part('month', CURRENT_DATE) >= 1 AND date_part('month', CURRENT_DATE) <= 4 THEN concat((date_part('year', CURRENT_DATE) - 1), '-09-01')::DATE
+                            WHEN date_part('month', CURRENT_DATE) >= 5 AND date_part('month', CURRENT_DATE) <= 8 THEN concat(date_part('year', CURRENT_DATE), '-01-01')::DATE
+                            WHEN date_part('month', CURRENT_DATE) >= 9 AND date_part('month', CURRENT_DATE) <= 12 THEN concat(date_part('year', CURRENT_DATE), '-05-01')::DATE
+                         END)
+                        THEN NULL::integer
                     ELSE tb1.gestacao_idade_gestacional_atual
                 END AS gestacao_idade_gestacional_atual,
                 CASE
-                    WHEN tb1.gestacao_data_dum IS NULL THEN NULL::integer
+                    WHEN tb1.gestacao_data_dum IS NULL 
+                        OR tb1.gestacao_data_dpp < (CASE -- Ou DPP é menor que a data de início do quadrimestre anterior
+                            WHEN date_part('month', CURRENT_DATE) >= 1 AND date_part('month', CURRENT_DATE) <= 4 THEN concat((date_part('year', CURRENT_DATE) - 1), '-09-01')::DATE
+                            WHEN date_part('month', CURRENT_DATE) >= 5 AND date_part('month', CURRENT_DATE) <= 8 THEN concat(date_part('year', CURRENT_DATE), '-01-01')::DATE
+                            WHEN date_part('month', CURRENT_DATE) >= 9 AND date_part('month', CURRENT_DATE) <= 12 THEN concat(date_part('year', CURRENT_DATE), '-05-01')::DATE
+                         END)                        
+                        THEN NULL::integer
                     ELSE tb1.gestacao_idade_gestacional_primeiro_atendimento
                 END AS gestacao_idade_gestacional_primeiro_atendimento,
             tb1.consulta_prenatal_ultima_data,
                 CASE
-                    WHEN tb1.gestacao_data_dum IS NULL THEN NULL::bigint
+                    WHEN tb1.gestacao_data_dum IS NULL 
+                        OR tb1.gestacao_data_dpp < (CASE -- Ou DPP é menor que a data de início do quadrimestre anterior
+                            WHEN date_part('month', CURRENT_DATE) >= 1 AND date_part('month', CURRENT_DATE) <= 4 THEN concat((date_part('year', CURRENT_DATE) - 1), '-09-01')::DATE
+                            WHEN date_part('month', CURRENT_DATE) >= 5 AND date_part('month', CURRENT_DATE) <= 8 THEN concat(date_part('year', CURRENT_DATE), '-01-01')::DATE
+                            WHEN date_part('month', CURRENT_DATE) >= 9 AND date_part('month', CURRENT_DATE) <= 12 THEN concat(date_part('year', CURRENT_DATE), '-05-01')::DATE
+                         END)     
+                        THEN NULL::bigint
                     ELSE tb1.consultas_pre_natal_validas
                 END AS consultas_pre_natal_validas,
                 CASE
-                    WHEN tb1.gestacao_data_dum IS NULL THEN 3
-                    WHEN tb1.atendimento_odontologico_realizado_valido THEN 1
-                    WHEN tb1.atendimento_odontologico_realizado_valido IS FALSE THEN 2
+                    WHEN tb1.gestacao_data_dum IS NULL 
+                        OR tb1.gestacao_data_dpp < (CASE -- Ou DPP é menor que a data de início do quadrimestre anterior
+                            WHEN date_part('month', CURRENT_DATE) >= 1 AND date_part('month', CURRENT_DATE) <= 4 THEN concat((date_part('year', CURRENT_DATE) - 1), '-09-01')::DATE
+                            WHEN date_part('month', CURRENT_DATE) >= 5 AND date_part('month', CURRENT_DATE) <= 8 THEN concat(date_part('year', CURRENT_DATE), '-01-01')::DATE
+                            WHEN date_part('month', CURRENT_DATE) >= 9 AND date_part('month', CURRENT_DATE) <= 12 THEN concat(date_part('year', CURRENT_DATE), '-05-01')::DATE
+                         END) 
+                         THEN 3 -- Retona '-' para gestantes sem DUM
+                    WHEN tb1.atendimento_odontologico_realizado_valido THEN 1 -- Atend. odontológico identificado
+                    WHEN tb1.atendimento_odontologico_realizado_valido IS FALSE THEN 2  -- Atend. odontológico não identificado
                     ELSE 0
                 END AS id_atendimento_odontologico,
                 CASE
-                    WHEN tb1.gestacao_data_dum IS NULL THEN 5
-                    WHEN tb1.exame_hiv_realizado_valido AND tb1.exame_sifilis_realizado_valido IS FALSE THEN 1
-                    WHEN tb1.exame_sifilis_realizado_valido AND tb1.exame_hiv_realizado_valido IS FALSE THEN 2
-                    WHEN tb1.exame_sifilis_realizado_valido IS FALSE AND tb1.exame_hiv_realizado_valido IS FALSE THEN 3
-                    WHEN tb1.exame_sifilis_realizado_valido AND tb1.exame_hiv_realizado_valido THEN 4
+                    WHEN tb1.gestacao_data_dum IS NULL 
+                        OR tb1.gestacao_data_dpp < (CASE -- Ou DPP é menor que a data de início do quadrimestre anterior
+                            WHEN date_part('month', CURRENT_DATE) >= 1 AND date_part('month', CURRENT_DATE) <= 4 THEN concat((date_part('year', CURRENT_DATE) - 1), '-09-01')::DATE
+                            WHEN date_part('month', CURRENT_DATE) >= 5 AND date_part('month', CURRENT_DATE) <= 8 THEN concat(date_part('year', CURRENT_DATE), '-01-01')::DATE
+                            WHEN date_part('month', CURRENT_DATE) >= 9 AND date_part('month', CURRENT_DATE) <= 12 THEN concat(date_part('year', CURRENT_DATE), '-05-01')::DATE
+                         END) 
+                         THEN 5 -- Retona '-' para gestantes sem DUM
+                    WHEN tb1.exame_hiv_realizado_valido AND tb1.exame_sifilis_realizado_valido IS FALSE THEN 1 -- Apenas Ex. de HIV realizados
+                    WHEN tb1.exame_sifilis_realizado_valido AND tb1.exame_hiv_realizado_valido IS FALSE THEN 2 -- Apenas Ex. de Sífilis realizados
+                    WHEN tb1.exame_sifilis_realizado_valido IS FALSE AND tb1.exame_hiv_realizado_valido IS FALSE THEN 3 -- Nenhum exame realizado
+                    WHEN tb1.exame_sifilis_realizado_valido AND tb1.exame_hiv_realizado_valido THEN 4 -- Os dois exames realizados
                     ELSE NULL::integer
                 END AS id_exame_hiv_sifilis,
                 CASE
                     WHEN tb1.possui_registro_aborto = 'Sim'::text THEN 10 -- Gestantes com registro de aborto
+                    WHEN tb1.gestacao_data_dpp IS NULL
+                        OR tb1.gestacao_data_dpp < (CASE -- Ou DPP é menor que a data de início do quadrimestre anterior
+                            WHEN date_part('month', CURRENT_DATE) >= 1 AND date_part('month', CURRENT_DATE) <= 4 THEN concat((date_part('year', CURRENT_DATE) - 1), '-09-01')::DATE
+                            WHEN date_part('month', CURRENT_DATE) >= 5 AND date_part('month', CURRENT_DATE) <= 8 THEN concat(date_part('year', CURRENT_DATE), '-01-01')::DATE
+                            WHEN date_part('month', CURRENT_DATE) >= 9 AND date_part('month', CURRENT_DATE) <= 12 THEN concat(date_part('year', CURRENT_DATE), '-05-01')::DATE
+                         END) 
+                         THEN 11 -- Gestantes sem DUM 
                     WHEN tb1.gestacao_data_dpp > CURRENT_DATE THEN 8 -- Gestantes ativas
                     WHEN tb1.gestacao_data_dpp <= CURRENT_DATE THEN 9 -- Gestantes encerradas
-                    WHEN tb1.gestacao_data_dpp IS NULL THEN 11 -- Gestantes sem DUM 
                     ELSE NULL::integer
                 END AS id_status_usuario,
                 CASE

--- a/bd_analitico/esus-backups/impulso_previne_dados_nominais/views_materializadas/painel_gestantes_lista_nominal.sql
+++ b/bd_analitico/esus-backups/impulso_previne_dados_nominais/views_materializadas/painel_gestantes_lista_nominal.sql
@@ -302,8 +302,8 @@ AS WITH dados_anonimizados_demo_vicosa AS (
                 END AS id_exame_hiv_sifilis,
                 CASE
                     WHEN tb1.possui_registro_aborto = 'Sim'::text THEN 10
-                    WHEN tb1.gestacao_data_dpp <= CURRENT_DATE THEN 8
-                    WHEN tb1.gestacao_data_dpp > CURRENT_DATE THEN 9
+                    WHEN tb1.gestacao_data_dpp > CURRENT_DATE THEN 8
+                    WHEN tb1.gestacao_data_dpp <= CURRENT_DATE THEN 9
                     WHEN tb1.gestacao_data_dpp IS NULL THEN 11
                     ELSE NULL::integer
                 END AS id_status_usuario,

--- a/bd_analitico/esus-backups/impulso_previne_dados_nominais/views_materializadas/painel_gestantes_lista_nominal.sql
+++ b/bd_analitico/esus-backups/impulso_previne_dados_nominais/views_materializadas/painel_gestantes_lista_nominal.sql
@@ -61,7 +61,8 @@ AS WITH dados_anonimizados_demo_vicosa AS (
                     lista_nominal_gestantes.exame_sifilis_hiv_realizado_valido,
                     lista_nominal_gestantes.criacao_data
                    FROM impulso_previne_dados_nominais.lista_nominal_gestantes_unificada lista_nominal_gestantes
-                  WHERE lista_nominal_gestantes.municipio_id_sus::text = '317130'::text) res
+                  WHERE lista_nominal_gestantes.municipio_id_sus::text = '317130'::text
+                  and lista_nominal_gestantes.equipe_ine is not null) res
              JOIN configuracoes.nomes_ficticios_gestantes nomes ON res.seq = nomes.seq
              JOIN configuracoes.nomes_ficticios_diabeticos nomes2 ON res.seq = nomes2.seq
         ), dados_anonimizados_impulsolandia AS (
@@ -125,7 +126,8 @@ AS WITH dados_anonimizados_demo_vicosa AS (
                     lista_nominal_gestantes.exame_sifilis_hiv_realizado_valido,
                     lista_nominal_gestantes.criacao_data
                    FROM impulso_previne_dados_nominais.lista_nominal_gestantes_unificada lista_nominal_gestantes
-                  WHERE lista_nominal_gestantes.municipio_id_sus::text = '317130'::text) res
+                  WHERE lista_nominal_gestantes.municipio_id_sus::text = '317130'::text
+                  and lista_nominal_gestantes.equipe_ine is not null) res
              JOIN configuracoes.nomes_ficticios_gestantes nomes ON res.seq = nomes.seq
              JOIN configuracoes.nomes_ficticios_diabeticos nomes2 ON res.seq = nomes2.seq
         ), dados_transmissoes_recentes AS (

--- a/bd_analitico/esus-backups/impulso_previne_dados_nominais/views_materializadas/painel_gestantes_lista_nominal.sql
+++ b/bd_analitico/esus-backups/impulso_previne_dados_nominais/views_materializadas/painel_gestantes_lista_nominal.sql
@@ -61,8 +61,7 @@ AS WITH dados_anonimizados_demo_vicosa AS (
                     lista_nominal_gestantes.exame_sifilis_hiv_realizado_valido,
                     lista_nominal_gestantes.criacao_data
                    FROM impulso_previne_dados_nominais.lista_nominal_gestantes_unificada lista_nominal_gestantes
-                  WHERE lista_nominal_gestantes.municipio_id_sus::text = '317130'::text
-                  and lista_nominal_gestantes.equipe_ine is not null) res
+                  WHERE lista_nominal_gestantes.municipio_id_sus::text = '317130'::text) res
              JOIN configuracoes.nomes_ficticios_gestantes nomes ON res.seq = nomes.seq
              JOIN configuracoes.nomes_ficticios_diabeticos nomes2 ON res.seq = nomes2.seq
         ), dados_anonimizados_impulsolandia AS (
@@ -126,8 +125,7 @@ AS WITH dados_anonimizados_demo_vicosa AS (
                     lista_nominal_gestantes.exame_sifilis_hiv_realizado_valido,
                     lista_nominal_gestantes.criacao_data
                    FROM impulso_previne_dados_nominais.lista_nominal_gestantes_unificada lista_nominal_gestantes
-                  WHERE lista_nominal_gestantes.municipio_id_sus::text = '317130'::text
-                  and lista_nominal_gestantes.equipe_ine is not null) res
+                  WHERE lista_nominal_gestantes.municipio_id_sus::text = '317130'::text) res
              JOIN configuracoes.nomes_ficticios_gestantes nomes ON res.seq = nomes.seq
              JOIN configuracoes.nomes_ficticios_diabeticos nomes2 ON res.seq = nomes2.seq
         ), dados_transmissoes_recentes AS (

--- a/docs/pull_request_template.md
+++ b/docs/pull_request_template.md
@@ -22,5 +22,5 @@ Exemplo de validações quantitativas
 [Análises quantitativas nessa planilha](https://docs.google.com/spreadsheets/d/16wIQONmHASLjEbpVE6aR3B9X3S6LHJ06kY1xXUU3kbY/edit#gid=788815878)
 
 Próximos passos: 
-- [] Comunicar ajustes importantes no canais próprios de cada lista nominal
+- [] Comunicar ajustes importantes nos canais próprios de cada lista nominal
 - [] Atualizar documentação de regras de negócio no [Notion](https://www.notion.so/impulsogov/Documenta-o-Listas-Nominais-8e919b380bc04783a02f2a74df9e81ce)  

--- a/docs/pull_request_template.md
+++ b/docs/pull_request_template.md
@@ -20,3 +20,7 @@ _**Validações obrigatórias**_
 
 Exemplo de validações quantitativas
 [Análises quantitativas nessa planilha](https://docs.google.com/spreadsheets/d/16wIQONmHASLjEbpVE6aR3B9X3S6LHJ06kY1xXUU3kbY/edit#gid=788815878)
+
+Próximos passos: 
+- [] Comunicar ajustes importantes no canais próprios de cada lista nominal
+- [] Atualizar documentação de regras de negócio no [Notion](https://www.notion.so/impulsogov/Documenta-o-Listas-Nominais-8e919b380bc04783a02f2a74df9e81ce)  

--- a/transmissor_impulso_esus/lista_nominal_citopatologico.sql
+++ b/transmissor_impulso_esus/lista_nominal_citopatologico.sql
@@ -392,6 +392,3 @@ lista_citopatologico as (
 		 from indicador_regras_de_negocio irn
 		 left join infos_mulheres_atendimento_individual_recente atr on irn.chave_mulher = atr.chave_mulher
 )select * from lista_citopatologico
--- retirar equipes de Palmeiras / nao e municipio parceiro
-WHERE equipe_ine_cadastro NOT IN ('0000071722', '0000071730', '0001511912', '0001846892', '0001847236', '0002275872')
-	AND equipe_ine_ultimo_atendimento NOT IN ('0000071722', '0000071730', '0001511912', '0001846892', '0001847236', '0002275872')

--- a/transmissor_impulso_esus/lista_nominal_diabeticos.sql
+++ b/transmissor_impulso_esus/lista_nominal_diabeticos.sql
@@ -295,6 +295,4 @@ LEFT JOIN cadastro_domiciliar_recente cdr
 LEFT JOIN atendimento_recente ar 
 	ON ar.chave_paciente = dd.chave_paciente
 	AND ar.ultimo_atendimento IS TRUE 
--- retirar equipes de Palmeiras / nao e municipio parceiro
-WHERE cir.equipe_ine_cadastro NOT IN ('0000071722', '0000071730', '0001511912', '0001846892', '0001847236', '0002275872')
-	AND ar.equipe_ine_atendimento NOT IN ('0000071722', '0000071730', '0001511912', '0001846892', '0001847236', '0002275872')
+

--- a/transmissor_impulso_esus/lista_nominal_gestantes.sql
+++ b/transmissor_impulso_esus/lista_nominal_gestantes.sql
@@ -511,4 +511,3 @@ WITH atendimentos_pre_natal AS (
      LEFT JOIN cadastro_individual_recente cir ON cir.chave_gestante = b.chave_gestante
      LEFT JOIN visita_domiciliar_recente vdr ON vdr.chave_gestante = b.chave_gestante
      LEFT JOIN cadastro_domiciliar_recente cdr ON cdr.chave_gestante = b.chave_gestante
-	where b.equipe_ine_atendimento not in ('0000071722', '0000071730', '0001511912', '0001846892', '0001847236', '0002275872') 

--- a/transmissor_impulso_esus/lista_nominal_hipertensos.sql
+++ b/transmissor_impulso_esus/lista_nominal_hipertensos.sql
@@ -296,6 +296,4 @@ LEFT JOIN cadastro_domiciliar_recente cdr
 LEFT JOIN atendimento_recente ar 
         ON ar.chave_paciente = dh.chave_paciente
         AND ar.ultimo_atendimento IS TRUE 
--- retirar equipes de Palmeiras / nao e municipio parceiro
-WHERE cir.equipe_ine_cadastro NOT IN ('0000071722', '0000071730', '0001511912', '0001846892', '0001847236', '0002275872')
-        AND ar.equipe_ine_atendimento NOT IN ('0000071722', '0000071730', '0001511912', '0001846892', '0001847236', '0002275872')
+

--- a/transmissor_impulso_esus/lista_nominal_vacinacao.sql
+++ b/transmissor_impulso_esus/lista_nominal_vacinacao.sql
@@ -1,0 +1,269 @@
+-- DENOMINADOR: crianças que completam 12 meses no quadrimestre atual
+WITH dados_cidadao_pec AS (
+    SELECT 
+        tfcp.co_seq_fat_cidadao_pec AS id_cidadao_pec,
+        replace(tfcp.no_cidadao || tfcp.co_dim_tempo_nascimento, ' ', '') AS chave_cidadao,
+        replace(tfcp.no_cidadao, '  ', ' ') AS cidadao_nome,
+        tempocidadaopec.dt_registro AS dt_nascimento,
+        (array_agg(tfcp.nu_cpf_cidadao) FILTER (WHERE tfcp.nu_cpf_cidadao IS NOT NULL) OVER (PARTITION BY replace(tfcp.no_cidadao || tfcp.co_dim_tempo_nascimento, ' ', '') ORDER BY tfcp.co_seq_fat_cidadao_pec DESC ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING))[1] AS cidadao_cpf,
+	    (array_agg(tfcp.nu_cns) FILTER (WHERE tfcp.nu_cns IS NOT NULL) OVER (PARTITION BY replace(tfcp.no_cidadao || tfcp.co_dim_tempo_nascimento, ' ', '') ORDER BY tfcp.co_seq_fat_cidadao_pec DESC ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING))[1] AS cidadao_cns,
+       	(array_agg(tfcp.st_faleceu) FILTER (WHERE tfcp.st_faleceu IS NOT NULL) OVER (PARTITION BY replace(tfcp.no_cidadao || tfcp.co_dim_tempo_nascimento, ' ', '') ORDER BY tfcp.co_seq_fat_cidadao_pec DESC ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING))[1] AS se_faleceu,
+	    (array_agg(tds.ds_sexo) FILTER (WHERE tds.ds_sexo IS NOT NULL) OVER (PARTITION BY replace(tfcp.no_cidadao || tfcp.co_dim_tempo_nascimento, ' ', '') ORDER BY tfcp.co_seq_fat_cidadao_pec DESC ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING))[1] AS cidadao_sexo,
+	    (array_agg(tfci.co_fat_cidadao_pec_responsvl ) FILTER (WHERE tfci.co_fat_cidadao_pec_responsvl IS NOT NULL) OVER (PARTITION BY replace(tfcp.no_cidadao || tfcp.co_dim_tempo_nascimento, ' ', '') ORDER BY tfcp.co_seq_fat_cidadao_pec DESC ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING))[1] AS  id_cidadao_pec_responsavel,
+	    EXTRACT(YEAR FROM age(CURRENT_DATE::timestamp WITH time zone, tempocidadaopec.dt_registro::timestamp WITH time zone)) * 12 + EXTRACT(MONTH FROM age(CURRENT_DATE::timestamp WITH time zone, tempocidadaopec.dt_registro::timestamp WITH time zone)) AS cidadao_idade_meses_atual,
+        case 
+            WHEN date_part('month', CURRENT_DATE) >= 1 AND date_part('month', CURRENT_DATE) <= 4 THEN concat(date_part('year', CURRENT_DATE ::date), '-01-01')::date
+            WHEN date_part('month', CURRENT_DATE) >= 5 AND date_part('month', CURRENT_DATE) <= 8 THEN concat(date_part('year', CURRENT_DATE ::date), '-05-01')::date
+            WHEN date_part('month', CURRENT_DATE) >= 9 AND date_part('month', CURRENT_DATE) <= 12 THEN concat(date_part('year', CURRENT_DATE ::date), '-09-01')::date
+            ELSE NULL::date
+        END AS data_inicio_quadrimestre,
+    	CASE
+            WHEN date_part('month', CURRENT_DATE) >= 1 AND date_part('month', CURRENT_DATE) <= 4 THEN concat(date_part('year', CURRENT_DATE ::date), '-04-30')::date
+            WHEN date_part('month', CURRENT_DATE) >= 5 AND date_part('month', CURRENT_DATE) <= 8 THEN concat(date_part('year', CURRENT_DATE ::date), '-08-31')::date
+            WHEN date_part('month', CURRENT_DATE) >= 9 AND date_part('month', CURRENT_DATE) <= 12 THEN concat(date_part('year', CURRENT_DATE ::date), '-12-31')::date
+            ELSE NULL::date
+        END AS data_fim_quadrimestre
+    FROM public.tb_fat_cidadao_pec tfcp
+    LEFT JOIN public.tb_dim_tempo tempocidadaopec ON tfcp.co_dim_tempo_nascimento = tempocidadaopec.co_seq_dim_tempo
+    LEFT JOIN public.tb_dim_sexo tds ON tds.co_seq_dim_sexo = tfcp.co_dim_sexo
+    left join public.tb_fat_cad_individual tfci on tfci.co_fat_cidadao_pec = tfcp.co_seq_fat_cidadao_pec 
+),
+selecao_denominador as (
+WITH base as (
+     SELECT 
+	     dcp.chave_cidadao,
+	     dcp.cidadao_nome,
+	     dcp.dt_nascimento,
+	     dcp.cidadao_cpf,
+	     dcp.cidadao_cns,
+	     dcp.cidadao_sexo,
+	     dcp.cidadao_idade_meses_atual,
+	     dcp.se_faleceu,
+	     responsavel.no_cidadao as cidadao_nome_responsavel,
+	     responsavel.nu_cns as cidadao_cns_responsavel,
+	     responsavel.nu_cpf_cidadao as cidadao_cpf_responsavel,
+	     EXTRACT(YEAR FROM age(dcp.data_inicio_quadrimestre::timestamp WITH time zone, dcp.dt_nascimento::timestamp WITH time zone)) * 12 + EXTRACT(MONTH FROM age(dcp.data_inicio_quadrimestre::timestamp WITH time zone, dcp.dt_nascimento::timestamp WITH time zone)) AS cidadao_idade_meses_inicio_quadri,
+	     EXTRACT(YEAR FROM age(dcp.data_fim_quadrimestre::timestamp WITH time zone, dcp.dt_nascimento::timestamp WITH time zone)) * 12 + EXTRACT(MONTH FROM age(dcp.data_fim_quadrimestre::timestamp WITH time zone, dcp.dt_nascimento::timestamp WITH time zone)) AS cidadao_idade_meses_fim_quadri
+	     FROM dados_cidadao_pec dcp
+	left join public.tb_fat_cidadao_pec responsavel on dcp.id_cidadao_pec_responsavel  = responsavel.co_seq_fat_cidadao_pec 
+	) SELECT * FROM base 
+	  WHERE cidadao_idade_meses_fim_quadri <= 16 
+	  GROUP BY 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13
+),
+historico_vacinacao as (
+	SELECT 
+        replace(tfcp.no_cidadao || tfcp.co_dim_tempo_nascimento, ' ', '') AS chave_cidadao,
+		tfv.co_seq_fat_vacinacao,
+		tfvv.co_seq_fat_vacinacao_vacina,
+		tf.ds_tipo_ficha as tipo_ficha,
+		imunobiologico.nu_identificador as codigo_vacina,
+		imunobiologico.no_imunobiologico as nome_vacina,
+		dose.no_dose_imunobiologico as dose_vacina,
+		tempo.dt_registro as data_registro_vacina,
+		unidadesaude.nu_cnes as estabelecimento_cnes_aplicacao_vacina,
+		unidadesaude.no_unidade_saude as estabelecimento_nome_aplicacao_vacina,
+		equipe.nu_ine as equipe_ine_aplicacao_vacina,
+		equipe.no_equipe as equipe_nome_aplicacao_vacina,
+		profissional.no_profissional as profissional_nome_aplicacao_vacina,
+		profissional.nu_cns,
+		cbo.nu_cbo,
+		cbo.no_cbo
+	FROM  public.tb_fat_cidadao_pec tfcp 
+	left join public.tb_fat_vacinacao tfv on tfcp.co_seq_fat_cidadao_pec  = tfv.co_fat_cidadao_pec
+	LEFT JOIN public.tb_fat_vacinacao_vacina tfvv on tfv.co_seq_fat_vacinacao = tfvv.co_fat_vacinacao 
+	LEFT JOIN public.tb_dim_imunobiologico imunobiologico on tfvv.co_dim_imunobiologico = imunobiologico.co_seq_dim_imunobiologico 
+	LEFT JOIN public.tb_dim_tempo tempo on tfvv.co_dim_tempo_vacina_aplicada  = tempo.co_seq_dim_tempo
+	LEFT JOIN public.tb_dim_dose_imunobiologico dose on dose.co_seq_dim_dose_imunobiologico = tfvv.co_dim_dose_imunobiologico 
+	LEFT JOIN public.tb_dim_equipe equipe on equipe.co_seq_dim_equipe = tfv.co_dim_equipe 
+	LEFT JOIN public.tb_dim_profissional profissional on profissional.co_seq_dim_profissional = tfvv.co_dim_profissional 
+	LEFT JOIN public.tb_dim_cbo cbo on cbo.co_seq_dim_cbo = tfvv.co_dim_cbo
+	LEFT JOIN public.tb_dim_unidade_saude unidadesaude on unidadesaude.co_seq_dim_unidade_saude = tfvv.co_dim_unidade_saude 
+	left join public.tb_dim_tipo_ficha tf on tfv.co_dim_tipo_ficha = tf.co_seq_dim_tipo_ficha 
+	join selecao_denominador sd on sd.chave_cidadao =  replace(tfcp.no_cidadao || tfcp.co_dim_tempo_nascimento, ' ', '') 
+	WHERE imunobiologico.nu_identificador in ('22','42','17','29','39','43','46','9')
+	AND (cbo.nu_cbo::text ~~ ANY (ARRAY['%2235%'::text, '%2251%'::text, '%2252%'::text, '%2253%'::text, '%2231%'::text, '%3222%'::text]))
+	GROUP BY 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16
+), 
+-- INFORMAÇÕES DE ATENDIMENTO MAIS RECENTE
+cadastro_individual_recente AS (
+-- Filtro de cadastro individual mais recente
+	WITH base AS (
+		SELECT 
+			sd.chave_cidadao,
+			tdt.dt_registro AS data_cadastro_individual,
+			nullif(tfci.nu_micro_area::text, '-'::text) AS micro_area_cad_individual,
+			uns.nu_cnes AS cnes_estabelecimento_cad_individual,
+			uns.no_unidade_saude AS estabelecimento_cad_individual,
+			eq.nu_ine AS ine_equipe_cad_individual,
+			eq.no_equipe AS equipe_cad_individual,
+			acs.no_profissional AS acs_cad_individual,
+			row_number() OVER (PARTITION BY sd.chave_cidadao ORDER BY tdt.dt_registro DESC) = 1 AS ultimo_cadastro_individual
+		FROM public.tb_fat_cad_individual tfci
+		JOIN public.tb_fat_cidadao_pec tfcpec
+			ON tfcpec.co_seq_fat_cidadao_pec = tfci.co_fat_cidadao_pec
+		JOIN selecao_denominador sd 
+			ON sd.chave_cidadao = replace(tfcpec.no_cidadao::text||tfcpec.co_dim_tempo_nascimento,' ','')
+		LEFT JOIN public.tb_dim_tempo tdt 
+			ON tdt.co_seq_dim_tempo = tfci.co_dim_tempo
+		LEFT JOIN public.tb_dim_equipe eq
+			ON eq.co_seq_dim_equipe = tfci.co_dim_equipe
+		LEFT JOIN public.tb_dim_profissional acs
+			ON acs.co_seq_dim_profissional = tfci.co_dim_profissional
+		LEFT JOIN public.tb_dim_unidade_saude uns
+			ON uns.co_seq_dim_unidade_saude = tfci.co_dim_unidade_saude  
+		)
+	SELECT * FROM base WHERE ultimo_cadastro_individual IS true
+), 
+atendimento_mais_recente AS (
+-- Filtro de atendimento individual mais recente
+with base as (	
+SELECT 
+			tfai.co_seq_fat_atd_ind::TEXT AS id_registro,
+			tdt.dt_registro AS data_registro,
+			sd.chave_cidadao,
+			tfcp.nu_telefone_celular AS paciente_telefone,
+			tdprof.nu_cns AS profissional_cns_atendimento_recente,
+			tdprof.no_profissional AS profissional_atendimento_recente,
+			uns.nu_cnes AS estabelecimento_cnes_atendimento_recente,
+			uns.no_unidade_saude AS estabelecimento_atendimento_recente,
+			eq.nu_ine AS ine_equipe_atendimento_recente,
+			eq.no_equipe AS equipe_atendimento_recente,
+			row_number() OVER (PARTITION BY sd.chave_cidadao ORDER BY tfai.co_seq_fat_atd_ind DESC) = 1 AS ultimo_atendimento_individual
+	    FROM public.tb_fat_atendimento_individual tfai
+	    JOIN public.tb_dim_tempo tdt 
+	    	ON tfai.co_dim_tempo = tdt.co_seq_dim_tempo
+	    LEFT JOIN public.tb_dim_profissional tdprof
+			ON tdprof.co_seq_dim_profissional = tfai.co_dim_profissional_1
+		LEFT JOIN public.tb_dim_equipe eq
+			ON eq.co_seq_dim_equipe = tfai.co_dim_equipe_1
+		LEFT JOIN public.tb_dim_unidade_saude uns 
+			ON uns.co_seq_dim_unidade_saude = tfai.co_dim_unidade_saude_1
+	    JOIN public.tb_fat_cidadao_pec tfcp 
+	    	ON tfcp.co_seq_fat_cidadao_pec = tfai.co_fat_cidadao_pec
+	  	JOIN selecao_denominador sd 
+			ON sd.chave_cidadao = replace(tfcp.no_cidadao::text||tfcp.co_dim_tempo_nascimento,' ','')
+		) 	
+		SELECT * FROM base WHERE ultimo_atendimento_individual IS true
+),
+visita_domiciliar_recente AS (
+-- Filtro de visita domiciliar mais recente
+	WITH base AS (
+		SELECT 
+			sd.chave_cidadao,
+		    tfcpec.co_seq_fat_cidadao_pec,
+			tdt.dt_registro AS data_visita_acs,
+			acs.no_profissional AS acs_visita_domiciliar,
+			row_number() OVER (PARTITION BY sd.chave_cidadao ORDER BY tdt.dt_registro DESC) = 1 AS ultima_visita_domiciliar
+		FROM public.tb_fat_visita_domiciliar visitadomiciliar
+		JOIN public.tb_fat_cidadao_pec tfcpec
+			ON tfcpec.co_seq_fat_cidadao_pec = visitadomiciliar.co_fat_cidadao_pec 
+		JOIN selecao_denominador sd
+			ON sd.chave_cidadao = replace(tfcpec.no_cidadao::text||tfcpec.co_dim_tempo_nascimento,' ','')
+		LEFT JOIN public.tb_dim_profissional acs
+			ON acs.co_seq_dim_profissional = visitadomiciliar.co_dim_profissional
+		LEFT JOIN public.tb_dim_tempo tdt 
+			ON tdt.co_seq_dim_tempo = visitadomiciliar.co_dim_tempo
+		)
+	SELECT * FROM base WHERE ultima_visita_domiciliar IS TRUE 
+), 
+cadastro_domiciliar_recente AS (
+-- Filtro de cadstro domiciliar mais recente
+	WITH base AS (
+		SELECT
+			sd.chave_cidadao,
+			tdt.dt_registro AS data_cadastro_dom_familia,
+			caddomiciliarfamilia.nu_micro_area AS micro_area_domicilio,
+			uns.nu_cnes AS cnes_estabelecimento_cad_dom_familia,
+			uns.no_unidade_saude AS estabelecimento_cad_dom_familia,
+			eq.nu_ine AS ine_equipe_cad_dom_familia,
+			eq.no_equipe AS equipe_cad_dom_familia,
+			acs.no_profissional AS acs_cad_dom_familia,
+			NULLIF(concat(cadomiciliar.no_logradouro, ', ', cadomiciliar.nu_num_logradouro), ', '::text) AS paciente_endereco,
+			row_number() OVER (PARTITION BY sd.chave_cidadao ORDER BY tdt.dt_registro DESC) = 1 AS ultimo_cadastro_domiciliar_familia
+		FROM public.tb_fat_cad_dom_familia caddomiciliarfamilia
+		JOIN public.tb_fat_cad_domiciliar cadomiciliar
+			ON cadomiciliar.co_seq_fat_cad_domiciliar = caddomiciliarfamilia.co_fat_cad_domiciliar
+		JOIN public.tb_fat_cidadao_pec tfcpec
+			ON tfcpec.co_seq_fat_cidadao_pec = caddomiciliarfamilia.co_fat_cidadao_pec
+		JOIN selecao_denominador sd
+			ON sd.chave_cidadao = replace(tfcpec.no_cidadao::text || tfcpec.co_dim_tempo_nascimento, ' ', '')
+		LEFT JOIN public.tb_dim_tempo tdt
+			ON tdt.co_seq_dim_tempo = caddomiciliarfamilia.co_dim_tempo
+		LEFT JOIN public.tb_dim_equipe eq
+			ON eq.co_seq_dim_equipe = caddomiciliarfamilia.co_dim_equipe
+		LEFT JOIN public.tb_dim_profissional acs
+			ON acs.co_seq_dim_profissional = caddomiciliarfamilia.co_dim_profissional
+		LEFT JOIN public.tb_dim_unidade_saude uns
+			ON uns.co_seq_dim_unidade_saude = caddomiciliarfamilia.co_dim_unidade_saude
+	)
+	SELECT * FROM base WHERE ultimo_cadastro_domiciliar_familia IS true
+),
+vinculacao_equipe AS (
+	SELECT
+		sd.chave_cidadao,
+		cir.data_cadastro_individual as data_ultimo_cadastro_individual,
+		cir.cnes_estabelecimento_cad_individual as estabelecimento_cnes_cadastro,
+		cir.estabelecimento_cad_individual as estabelecimento_nome_cadastro, 
+		cir.ine_equipe_cad_individual as equipe_ine_cadastro,
+		cir.equipe_cad_individual as equipe_nome_cadastro,
+		cir.acs_cad_individual as acs_nome_cadastro,
+		ar.estabelecimento_cnes_atendimento_recente as estabelecimento_cnes_atendimento, 
+		ar.estabelecimento_atendimento_recente as estabelecimento_nome_atendimento, 
+		ar.ine_equipe_atendimento_recente as equipe_ine_atendimento,
+		ar.equipe_atendimento_recente as equipe_nome_atendimento,
+		ar.data_registro as data_ultimo_atendimento_individual,
+		vdr.data_visita_acs as data_ultima_vista_domiciliar,
+		vdr.acs_visita_domiciliar as acs_nome_visita
+	FROM selecao_denominador sd
+	LEFT JOIN cadastro_individual_recente cir
+		ON cir.chave_cidadao = sd.chave_cidadao
+	LEFT JOIN visita_domiciliar_recente vdr
+		ON vdr.chave_cidadao = sd.chave_cidadao
+	LEFT JOIN cadastro_domiciliar_recente cdr
+		ON cdr.chave_cidadao = sd.chave_cidadao
+	left join atendimento_mais_recente ar
+		on ar.chave_cidadao = sd.chave_cidadao
+	GROUP BY 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14
+) select
+	sd.chave_cidadao,
+	sd.cidadao_nome,
+	sd.cidadao_cpf,
+	sd.cidadao_cns,
+	sd.cidadao_sexo,
+	sd.dt_nascimento,
+	sd.cidadao_nome_responsavel,
+	sd.cidadao_cns_responsavel,
+	sd.cidadao_cpf_responsavel,
+	sd.cidadao_idade_meses_atual,
+	sd.cidadao_idade_meses_inicio_quadri,
+	sd.cidadao_idade_meses_fim_quadri,
+	sd.se_faleceu,
+	hvc.co_seq_fat_vacinacao,
+	hvc.co_seq_fat_vacinacao_vacina,
+	hvc.tipo_ficha,
+	hvc.codigo_vacina,
+	hvc.nome_vacina,
+	hvc.dose_vacina,
+	hvc.data_registro_vacina,
+	hvc.estabelecimento_cnes_aplicacao_vacina,
+	hvc.estabelecimento_nome_aplicacao_vacina,
+	hvc.equipe_ine_aplicacao_vacina,
+	hvc.equipe_nome_aplicacao_vacina,
+	hvc.profissional_nome_aplicacao_vacina,
+	vinculacao.data_ultimo_cadastro_individual,
+	vinculacao.estabelecimento_cnes_cadastro,
+	vinculacao.estabelecimento_nome_cadastro, 
+	vinculacao.equipe_ine_cadastro,
+	vinculacao.equipe_nome_cadastro,
+	vinculacao.acs_nome_cadastro,
+	vinculacao.estabelecimento_cnes_atendimento, 
+	vinculacao.estabelecimento_nome_atendimento, 
+	vinculacao.equipe_ine_atendimento,
+	vinculacao.equipe_nome_atendimento,
+	vinculacao.data_ultimo_atendimento_individual,
+	vinculacao.data_ultima_vista_domiciliar,
+	vinculacao.acs_nome_visita,
+	now() as criacao_data
+from selecao_denominador sd 
+	left join historico_vacinacao hvc on sd.chave_cidadao=hvc.chave_cidadao 
+	left join vinculacao_equipe vinculacao on vinculacao.chave_cidadao = sd.chave_cidadao


### PR DESCRIPTION
_**Alterações de código das listas nominais**_

**Motivo do ajuste:**
Foi sinalizado um bug no painel Demo-Viçosa, onde havia um elevado número de pacientes com o valor “null” para a equipe de vinculação. Isso ocorreu pois nos códigos das views dos painéis de diabéticos, hipertensos e citopatológico, na CTE que anonimiza os dados para a Demo-Viçosa a fonte dos dados eram as tabelas que armazenam os dados “brutos” recebidos nas transmissões e não os dados com as regras de negócio já aplicadas. Dessa forma, a CTE estava trazendo também os pacientes cujos códigos INE eram nulos tanto para ambas equipes de atendimento e cadastro.

**O que está sendo alterado:**
Na CTE que anonimiza os dados nos códigos dos paineis de diabéticos, hipertensos e citopatológico, é ajustada a fonte dos dados para as views que já aplicam as primeiras regras de negócio (filtrando para o id sus de Viçosa) e não da tabela que recebe os dados das transmissões


Ajustes que não demandam validações aprofundadas.