### PR TITLE
Correção da regra de status do painel de gestantes

### DIFF
--- a/bd_analitico/esus-backups/impulso_previne_dados_nominais/views_materializadas/painel_gestantes_lista_nominal.sql
+++ b/bd_analitico/esus-backups/impulso_previne_dados_nominais/views_materializadas/painel_gestantes_lista_nominal.sql
@@ -301,10 +301,10 @@ AS WITH dados_anonimizados_demo_vicosa AS (
                     ELSE NULL::integer
                 END AS id_exame_hiv_sifilis,
                 CASE
-                    WHEN tb1.possui_registro_aborto = 'Sim'::text THEN 10
-                    WHEN tb1.gestacao_data_dpp > CURRENT_DATE THEN 8
-                    WHEN tb1.gestacao_data_dpp <= CURRENT_DATE THEN 9
-                    WHEN tb1.gestacao_data_dpp IS NULL THEN 11
+                    WHEN tb1.possui_registro_aborto = 'Sim'::text THEN 10 -- Gestantes com registro de aborto
+                    WHEN tb1.gestacao_data_dpp > CURRENT_DATE THEN 8 -- Gestantes ativas
+                    WHEN tb1.gestacao_data_dpp <= CURRENT_DATE THEN 9 -- Gestantes encerradas
+                    WHEN tb1.gestacao_data_dpp IS NULL THEN 11 -- Gestantes sem DUM 
                     ELSE NULL::integer
                 END AS id_status_usuario,
                 CASE


### PR DESCRIPTION
_**Alterações de código das listas nominais**_

**Motivo do ajuste:**
A regra estava invertida em relação as gestante ativas e encerradas

**O que está sendo alterado:**
Regra que define status das gestante. 
Inversão da regra entre gestantes encerradas e gestantes ativas

_**Validações obrigatórias**_
Correção muito pontual, validações não necessárias 

