### PR TITLE
Corrige campo atualização data nas views unificadas de crônicos

### DIFF
--- a/bd_analitico/esus-backups/impulso_previne_dados_nominais/views_materializadas/lista_nominal_diabeticos_unificada.sql
+++ b/bd_analitico/esus-backups/impulso_previne_dados_nominais/views_materializadas/lista_nominal_diabeticos_unificada.sql
@@ -1,3 +1,4 @@
+-- impulso_previne_dados_nominais.lista_nominal_diabeticos_unificada source
 
 CREATE MATERIALIZED VIEW impulso_previne_dados_nominais.lista_nominal_diabeticos_unificada
 TABLESPACE pg_default
@@ -31,6 +32,6 @@ AS SELECT consulta_tabelas_lista_nominal_diabeticos.municipio_id_sus,
     consulta_tabelas_lista_nominal_diabeticos.se_faleceu,
     consulta_tabelas_lista_nominal_diabeticos.se_mudou,
     consulta_tabelas_lista_nominal_diabeticos.criacao_data,
-    consulta_tabelas_lista_nominal_diabeticos.atualizacao_data
+    now() AS atualizacao_data
    FROM impulso_previne_dados_nominais.consulta_tabelas_lista_nominal_diabeticos() consulta_tabelas_lista_nominal_diabeticos(municipio_id_sus, quadrimestre_atual, realizou_solicitacao_hemoglobina_ultimos_6_meses, dt_solicitacao_hemoglobina_glicada_mais_recente, realizou_consulta_ultimos_6_meses, dt_consulta_mais_recente, co_seq_fat_cidadao_pec, cidadao_cpf, cidadao_cns, cidadao_nome, cidadao_nome_social, cidadao_sexo, dt_nascimento, estabelecimento_cnes_atendimento, estabelecimento_cnes_cadastro, estabelecimento_nome_atendimento, estabelecimento_nome_cadastro, equipe_ine_atendimento, equipe_ine_cadastro, equipe_nome_atendimento, equipe_nome_cadastro, acs_nome_cadastro, acs_nome_visita, possui_diabetes_autoreferida, possui_diabetes_diagnosticada, data_ultimo_cadastro, dt_ultima_consulta, se_faleceu, se_mudou, criacao_data, atualizacao_data)
 WITH DATA;

--- a/bd_analitico/esus-backups/impulso_previne_dados_nominais/views_materializadas/lista_nominal_hipertensos_unificada.sql
+++ b/bd_analitico/esus-backups/impulso_previne_dados_nominais/views_materializadas/lista_nominal_hipertensos_unificada.sql
@@ -1,3 +1,4 @@
+-- impulso_previne_dados_nominais.lista_nominal_hipertensos_unificada source
 
 CREATE MATERIALIZED VIEW impulso_previne_dados_nominais.lista_nominal_hipertensos_unificada
 TABLESPACE pg_default
@@ -31,6 +32,6 @@ AS SELECT consulta_tabelas_lista_nominal_hipertensos.municipio_id_sus,
     consulta_tabelas_lista_nominal_hipertensos.se_faleceu,
     consulta_tabelas_lista_nominal_hipertensos.se_mudou,
     consulta_tabelas_lista_nominal_hipertensos.criacao_data,
-    consulta_tabelas_lista_nominal_hipertensos.atualizacao_data
+    now() AS atualizacao_data
    FROM impulso_previne_dados_nominais.consulta_tabelas_lista_nominal_hipertensos() consulta_tabelas_lista_nominal_hipertensos(municipio_id_sus, quadrimestre_atual, realizou_afericao_ultimos_6_meses, dt_afericao_pressao_mais_recente, realizou_consulta_ultimos_6_meses, dt_consulta_mais_recente, co_seq_fat_cidadao_pec, cidadao_cpf, cidadao_cns, cidadao_nome, cidadao_nome_social, cidadao_sexo, dt_nascimento, estabelecimento_cnes_atendimento, estabelecimento_cnes_cadastro, estabelecimento_nome_atendimento, estabelecimento_nome_cadastro, equipe_ine_atendimento, equipe_ine_cadastro, equipe_nome_atendimento, equipe_nome_cadastro, acs_nome_cadastro, acs_nome_visita, possui_hipertensao_autorreferida, possui_hipertensao_diagnosticada, data_ultimo_cadastro, dt_ultima_consulta, se_faleceu, se_mudou, criacao_data, atualizacao_data)
 WITH DATA;


### PR DESCRIPTION
_**Alterações de código das listas nominais**_

**Motivo do ajuste:**
Ajuste dos campos de atualização data das listas nominais unificadas de crônicos para corrigir os alertas do metabase no slack.

**O que está sendo alterado:**
O campo atualizacao_data das views lista_nominal_unificada_diabeticos e lista_nominal_unificada_cronicos estava vindo como nulo. Foi atribuído para esse campo em ambas as listas a data e hora corrente da última atualização com a função now().


_**Validações obrigatórias**_


Alteração simples sem necessidade de validação ou ajuste na documentação.