### PR TITLE
Corrige filtro de periodo da view impulso_previne.capitacao_ponderada_contagem_equipes

### DIFF
--- a/bd_analitico/esus-backups/impulso_previne_dados_nominais/views_materializadas/painel_citopatologico_lista_nominal.sql
+++ b/bd_analitico/esus-backups/impulso_previne_dados_nominais/views_materializadas/painel_citopatologico_lista_nominal.sql
@@ -66,7 +66,8 @@ AS WITH dados_anonimizados_demo_vicosa AS (
                     tb1_1.acs_nome_visita,
                     tb1_1.criacao_data
                    FROM impulso_previne_dados_nominais.lista_nominal_citopatologico_unificada tb1_1
-                   where tb1_1.municipio_id_sus::text = '317130'::text) res
+                  WHERE tb1_1.municipio_id_sus::text = '317130'::text
+                  and tb1_1.equipe_ine_ultimo_atendimento is not null and tb1_1.equipe_ine_cadastro is not null ) res
              JOIN configuracoes.nomes_ficticios_citopatologico nomes ON res.seq = nomes.seq
              JOIN configuracoes.nomes_ficticios_gestantes nomes2 ON res.seq = nomes2.seq
         ), dados_anonimizados_impulsolandia AS (
@@ -134,7 +135,8 @@ AS WITH dados_anonimizados_demo_vicosa AS (
                     tb1_1.acs_nome_visita,
                     tb1_1.criacao_data
                    FROM impulso_previne_dados_nominais.lista_nominal_citopatologico_unificada tb1_1
-                   where tb1_1.municipio_id_sus::text = '317130'::text) res
+                  WHERE tb1_1.municipio_id_sus::text = '317130'::text
+                  and tb1_1.equipe_ine_ultimo_atendimento is not null and tb1_1.equipe_ine_cadastro is not null ) res
              JOIN configuracoes.nomes_ficticios_citopatologico nomes ON res.seq = nomes.seq
              JOIN configuracoes.nomes_ficticios_gestantes nomes2 ON res.seq = nomes2.seq
         ), dados_transmissoes_recentes AS (

--- a/bd_analitico/esus-backups/impulso_previne_dados_nominais/views_materializadas/painel_citopatologico_lista_nominal.sql
+++ b/bd_analitico/esus-backups/impulso_previne_dados_nominais/views_materializadas/painel_citopatologico_lista_nominal.sql
@@ -65,7 +65,8 @@ AS WITH dados_anonimizados_demo_vicosa AS (
                     tb1_1.acs_nome_ultimo_atendimento,
                     tb1_1.acs_nome_visita,
                     tb1_1.criacao_data
-                   FROM dados_nominais_mg_vicosa.lista_nominal_citopatologico tb1_1) res
+                   FROM dados_nominais_mg_vicosa.lista_nominal_citopatologico tb1_1
+                   where tb1_1.equipe_ine_cadastro is not null and tb1_1.equipe_ine_ultimo_atendimento is not null) res
              JOIN configuracoes.nomes_ficticios_citopatologico nomes ON res.seq = nomes.seq
              JOIN configuracoes.nomes_ficticios_gestantes nomes2 ON res.seq = nomes2.seq
         ), dados_anonimizados_impulsolandia AS (
@@ -132,7 +133,8 @@ AS WITH dados_anonimizados_demo_vicosa AS (
                     tb1_1.acs_nome_ultimo_atendimento,
                     tb1_1.acs_nome_visita,
                     tb1_1.criacao_data
-                   FROM dados_nominais_mg_vicosa.lista_nominal_citopatologico tb1_1) res
+                   FROM dados_nominais_mg_vicosa.lista_nominal_citopatologico tb1_1
+                   where tb1_1.equipe_ine_cadastro is not null and tb1_1.equipe_ine_ultimo_atendimento is not null ) res
              JOIN configuracoes.nomes_ficticios_citopatologico nomes ON res.seq = nomes.seq
              JOIN configuracoes.nomes_ficticios_gestantes nomes2 ON res.seq = nomes2.seq
         ), dados_transmissoes_recentes AS (
@@ -267,62 +269,73 @@ AS WITH dados_anonimizados_demo_vicosa AS (
             dados_transmissoes_recentes.acs_nome_visita,
             dados_transmissoes_recentes.criacao_data
            FROM dados_transmissoes_recentes
+        ), data_registro_producao AS (
+         SELECT une_as_bases.municipio_id_sus,
+            impulso_previne_dados_nominais.equipe_ine(une_as_bases.municipio_id_sus::text, COALESCE(une_as_bases.equipe_ine_cadastro, une_as_bases.equipe_ine_ultimo_atendimento)::text) AS ine_master,
+            max(GREATEST(une_as_bases.dt_ultimo_exame, une_as_bases.dt_ultimo_atendimento, une_as_bases.dt_ultimo_cadastro)) AS dt_registro_producao_mais_recente,
+            min(LEAST(une_as_bases.dt_ultimo_exame, une_as_bases.dt_ultimo_atendimento, une_as_bases.dt_ultimo_cadastro)) AS dt_registro_producao_mais_antigo
+           FROM une_as_bases
+          GROUP BY une_as_bases.municipio_id_sus, (impulso_previne_dados_nominais.equipe_ine(une_as_bases.municipio_id_sus::text, COALESCE(une_as_bases.equipe_ine_cadastro, une_as_bases.equipe_ine_ultimo_atendimento)::text))
+        ), tabela_aux AS (
+         SELECT tb1.municipio_id_sus,
+            concat(tb2.nome, ' - ', tb2.uf_sigla) AS municipio_uf,
+            tb1.paciente_nome,
+                CASE
+                    WHEN tb1.cidadao_cpf IS NULL THEN to_char(tb1.dt_nascimento::timestamp with time zone, 'DD/MM/YYYY'::text)
+                    ELSE concat("substring"(tb1.cidadao_cpf, 1, 3), '.', "substring"(tb1.cidadao_cpf, 4, 3), '.', "substring"(tb1.cidadao_cpf, 7, 3), '-', "substring"(tb1.cidadao_cpf, 10, 2))
+                END AS cidadao_cpf_dt_nascimento,
+                CASE
+                    WHEN tb1.status_exame::text = ANY (ARRAY['exame_realizado_antes_dos_25'::character varying::text, 'exame_nunca_realizado'::character varying::text]) THEN '-'::text
+                    ELSE to_char(tb1.data_projetada_proximo_exame::timestamp with time zone, 'DD/MM/YYYY'::text)
+                END AS vencimento_da_coleta,
+                CASE
+                    WHEN tb1.status_exame::text = 'exame_em_dia'::text THEN 'Em dia'::text
+                    ELSE to_char(tb1.data_limite_a_realizar_proximo_exame::timestamp with time zone, 'DD/MM/YYYY'::text)
+                END AS prazo_proxima_coleta,
+            tb1.paciente_idade_atual AS idade,
+            COALESCE(tb1.acs_nome_visita, tb1.acs_nome_cadastro) AS acs_nome,
+            COALESCE(tb1.estabelecimento_cnes_cadastro, tb1.estabelecimento_cnes_ultimo_atendimento) AS estabelecimento_cnes,
+            COALESCE(tb1.estabelecimento_nome_cadastro, tb1.estabelecimento_nome_ultimo_atendimento) AS estabelecimento_nome,
+            COALESCE(tb1.equipe_ine_cadastro, tb1.equipe_ine_ultimo_atendimento) AS equipe_ine,
+            impulso_previne_dados_nominais.equipe_ine(tb1.municipio_id_sus::text, COALESCE(tb1.equipe_ine_cadastro, tb1.equipe_ine_ultimo_atendimento)::text) AS ine_master,
+            impulso_previne_dados_nominais.equipe_ine(tb1.municipio_id_sus::text, COALESCE(tb1.equipe_nome_cadastro, tb1.equipe_nome_ultimo_atendimento)::text) AS equipe_nome,
+                CASE
+                    WHEN tb1.status_exame::text = 'exame_em_dia'::text THEN 12
+                    WHEN tb1.status_exame::text = 'exame_nunca_realizado'::text THEN 13
+                    WHEN tb1.status_exame::text = 'exame_realizado_antes_dos_25'::text THEN 14
+                    WHEN tb1.status_exame::text = 'exame_vence_no_quadrimestre_atual'::text THEN 15
+                    WHEN tb1.status_exame::text = 'exame_vencido'::text THEN 16
+                    ELSE NULL::integer
+                END AS id_status_usuario,
+                CASE
+                    WHEN tb1.paciente_idade_atual <= 39 THEN 6
+                    WHEN tb1.paciente_idade_atual >= 40 AND tb1.paciente_idade_atual <= 49 THEN 7
+                    WHEN tb1.paciente_idade_atual >= 50 AND tb1.paciente_idade_atual <= 64 THEN 8
+                    ELSE NULL::integer
+                END AS id_faixa_etaria,
+            tb1.criacao_data,
+            CURRENT_TIMESTAMP AS atualizacao_data
+           FROM une_as_bases tb1
+             LEFT JOIN listas_de_codigos.municipios tb2 ON tb1.municipio_id_sus::bpchar = tb2.id_sus
         )
-, data_registro_producao AS (
-    SELECT 
-        municipio_id_sus,
-        impulso_previne_dados_nominais.equipe_ine(municipio_id_sus::text, COALESCE(equipe_ine_cadastro, equipe_ine_ultimo_atendimento)::text) AS ine_master,
-        MAX(GREATEST(dt_ultimo_exame,dt_ultimo_atendimento,dt_ultimo_cadastro)) AS dt_registro_producao_mais_recente,
-        MIN(LEAST(dt_ultimo_exame,dt_ultimo_atendimento,dt_ultimo_cadastro)) AS dt_registro_producao_mais_antigo
-    FROM une_as_bases
-    GROUP BY 1, 2
-)
-, tabela_aux AS (
- SELECT tb1.municipio_id_sus,
-    concat(tb2.nome, ' - ', tb2.uf_sigla) AS municipio_uf,
-    tb1.paciente_nome,
-        CASE
-            WHEN tb1.cidadao_cpf IS NULL THEN to_char(tb1.dt_nascimento::timestamp with time zone, 'DD/MM/YYYY'::text)
-            ELSE concat("substring"(tb1.cidadao_cpf, 1, 3), '.', "substring"(tb1.cidadao_cpf, 4, 3), '.', "substring"(tb1.cidadao_cpf, 7, 3), '-', "substring"(tb1.cidadao_cpf, 10, 2))
-        END AS cidadao_cpf_dt_nascimento,
-        CASE
-            WHEN tb1.status_exame::text = ANY (ARRAY['exame_realizado_antes_dos_25'::character varying::text, 'exame_nunca_realizado'::character varying::text]) THEN '-'::text
-            ELSE to_char(tb1.data_projetada_proximo_exame::timestamp with time zone, 'DD/MM/YYYY'::text)
-        END AS vencimento_da_coleta,
-        CASE
-            WHEN tb1.status_exame::text = 'exame_em_dia'::text THEN 'Em dia'::text
-            ELSE to_char(tb1.data_limite_a_realizar_proximo_exame::timestamp with time zone, 'DD/MM/YYYY'::text)
-        END AS prazo_proxima_coleta,
-    tb1.paciente_idade_atual AS idade,
-    COALESCE(tb1.acs_nome_visita, tb1.acs_nome_cadastro) AS acs_nome,
-    COALESCE(tb1.estabelecimento_cnes_cadastro, tb1.estabelecimento_cnes_ultimo_atendimento) AS estabelecimento_cnes,
-    COALESCE(tb1.estabelecimento_nome_cadastro, tb1.estabelecimento_nome_ultimo_atendimento) AS estabelecimento_nome,
-    COALESCE(tb1.equipe_ine_cadastro, tb1.equipe_ine_ultimo_atendimento) AS equipe_ine,
-    impulso_previne_dados_nominais.equipe_ine(tb1.municipio_id_sus::text, COALESCE(tb1.equipe_ine_cadastro, tb1.equipe_ine_ultimo_atendimento)::text) AS ine_master,
-    impulso_previne_dados_nominais.equipe_ine(tb1.municipio_id_sus::text, COALESCE(tb1.equipe_nome_cadastro, tb1.equipe_nome_ultimo_atendimento)::text) AS equipe_nome,
-        CASE
-            WHEN tb1.status_exame::text = 'exame_em_dia'::text THEN 12
-            WHEN tb1.status_exame::text = 'exame_nunca_realizado'::text THEN 13
-            WHEN tb1.status_exame::text = 'exame_realizado_antes_dos_25'::text THEN 14
-            WHEN tb1.status_exame::text = 'exame_vence_no_quadrimestre_atual'::text THEN 15
-            WHEN tb1.status_exame::text = 'exame_vencido'::text THEN 16
-            ELSE NULL::integer
-        END AS id_status_usuario,
-        CASE
-            WHEN tb1.paciente_idade_atual <= 39 THEN 6
-            WHEN tb1.paciente_idade_atual >= 40 AND tb1.paciente_idade_atual <= 49 THEN 7
-            WHEN tb1.paciente_idade_atual >= 50 AND tb1.paciente_idade_atual <= 64 THEN 8
-            ELSE NULL::integer
-        END AS id_faixa_etaria,
-    tb1.criacao_data,
-    CURRENT_TIMESTAMP AS atualizacao_data
-   FROM une_as_bases tb1
-     LEFT JOIN listas_de_codigos.municipios tb2 ON tb1.municipio_id_sus::bpchar = tb2.id_sus
-) SELECT
-    tabela_aux.*,
+ SELECT tabela_aux.municipio_id_sus,
+    tabela_aux.municipio_uf,
+    tabela_aux.paciente_nome,
+    tabela_aux.cidadao_cpf_dt_nascimento,
+    tabela_aux.vencimento_da_coleta,
+    tabela_aux.prazo_proxima_coleta,
+    tabela_aux.idade,
+    tabela_aux.acs_nome,
+    tabela_aux.estabelecimento_cnes,
+    tabela_aux.estabelecimento_nome,
+    tabela_aux.equipe_ine,
+    tabela_aux.ine_master,
+    tabela_aux.equipe_nome,
+    tabela_aux.id_status_usuario,
+    tabela_aux.id_faixa_etaria,
+    tabela_aux.criacao_data,
+    tabela_aux.atualizacao_data,
     drp.dt_registro_producao_mais_recente
-FROM tabela_aux
-LEFT JOIN data_registro_producao drp 
-    ON drp.municipio_id_sus = tabela_aux.municipio_id_sus
-    AND drp.ine_master = tabela_aux.ine_master
+   FROM tabela_aux
+     LEFT JOIN data_registro_producao drp ON drp.municipio_id_sus::text = tabela_aux.municipio_id_sus::text AND drp.ine_master = tabela_aux.ine_master
 WITH DATA;

--- a/bd_analitico/esus-backups/impulso_previne_dados_nominais/views_materializadas/painel_citopatologico_lista_nominal.sql
+++ b/bd_analitico/esus-backups/impulso_previne_dados_nominais/views_materializadas/painel_citopatologico_lista_nominal.sql
@@ -67,7 +67,7 @@ AS WITH dados_anonimizados_demo_vicosa AS (
                     tb1_1.acs_nome_visita,
                     tb1_1.criacao_data
                    FROM impulso_previne_dados_nominais.lista_nominal_citopatologico_unificada tb1_1
-                  WHERE tb1_1.municipio_id_sus::text = '317130'::text AND tb1_1.equipe_ine_ultimo_atendimento IS NOT NULL AND tb1_1.equipe_ine_ultimo_atendimento::text <> '-'::text AND tb1_1.equipe_ine_cadastro IS NOT NULL AND tb1_1.equipe_ine_cadastro::text <> '-'::text AND tb1_1.equipe_nome_ultimo_atendimento IS NOT NULL AND (tb1_1.equipe_nome_ultimo_atendimento::text <> ALL (ARRAY['EMAD'::character varying, 'EAPP DE SAUDE VICOSA'::character varying, 'ESF BOM JESUS III'::character varying, 'EMULTI SAO JOSE CIDADE NOVA BA'::character varying, 'EMAD'::character varying, 'EMULTI SAO JOSE DO TRIUNFO'::character varying, 'EMULTI BOM JESUS'::character varying]::text[])) AND tb1_1.equipe_nome_cadastro IS NOT NULL AND tb1_1.equipe_nome_cadastro::text <> 'EMAD'::text) res
+                  WHERE tb1_1.municipio_id_sus::text = '317130'::text AND tb1_1.equipe_ine_ultimo_atendimento IS NOT NULL AND tb1_1.equipe_ine_ultimo_atendimento::text <> '-'::text AND tb1_1.equipe_ine_cadastro IS NOT NULL AND tb1_1.equipe_ine_cadastro::text <> '-'::text AND tb1_1.equipe_nome_ultimo_atendimento IS NOT NULL AND (tb1_1.equipe_nome_ultimo_atendimento::text <> ALL (ARRAY['EMAD'::character varying::text, 'EAPP DE SAUDE VICOSA'::character varying::text, 'ESF BOM JESUS III'::character varying::text, 'EMULTI SAO JOSE CIDADE NOVA BA'::character varying::text, 'EMAD'::character varying::text, 'EMULTI SAO JOSE DO TRIUNFO'::character varying::text, 'EMULTI BOM JESUS'::character varying::text])) AND tb1_1.equipe_nome_cadastro IS NOT NULL AND tb1_1.equipe_nome_cadastro::text <> 'EMAD'::text) res
              LEFT JOIN configuracoes.nomes_ficticios_citopatologico nomes ON res.seq = nomes.seq
              LEFT JOIN configuracoes.nomes_ficticios_hipertensos nomes2 ON res.seq = nomes2.seq
         ), dados_anonimizados_impulsolandia AS (
@@ -135,9 +135,9 @@ AS WITH dados_anonimizados_demo_vicosa AS (
                     tb1_1.acs_nome_visita,
                     tb1_1.criacao_data
                    FROM impulso_previne_dados_nominais.lista_nominal_citopatologico_unificada tb1_1
-                  WHERE tb1_1.municipio_id_sus::text = '317130'::text) res
-             JOIN configuracoes.nomes_ficticios_citopatologico nomes ON res.seq = nomes.seq
-             JOIN configuracoes.nomes_ficticios_gestantes nomes2 ON res.seq = nomes2.seq
+                  WHERE tb1_1.municipio_id_sus::text = '317130'::text AND tb1_1.equipe_ine_ultimo_atendimento IS NOT NULL AND tb1_1.equipe_ine_ultimo_atendimento::text <> '-'::text AND tb1_1.equipe_ine_cadastro IS NOT NULL AND tb1_1.equipe_nome_ultimo_atendimento IS NOT NULL AND (tb1_1.equipe_nome_ultimo_atendimento::text <> ALL (ARRAY['EMAD'::character varying::text, 'EAPP DE SAUDE VICOSA'::character varying::text, 'ESF BOM JESUS III'::character varying::text, 'EMULTI SAO JOSE CIDADE NOVA BA'::character varying::text, 'EMAD'::character varying::text, 'EMULTI SAO JOSE DO TRIUNFO'::character varying::text, 'EMULTI BOM JESUS'::character varying::text])) AND tb1_1.equipe_nome_cadastro IS NOT NULL AND tb1_1.equipe_nome_cadastro::text <> 'EMAD'::text) res
+             LEFT JOIN configuracoes.nomes_ficticios_citopatologico nomes ON res.seq = nomes.seq
+             LEFT JOIN configuracoes.nomes_ficticios_hipertensos nomes2 ON res.seq = nomes2.seq
         ), dados_transmissoes_recentes AS (
          SELECT tb1_1.municipio_id_sus,
             tb1_1.quadrimestre_atual,

--- a/bd_analitico/esus-backups/impulso_previne_dados_nominais/views_materializadas/painel_citopatologico_lista_nominal.sql
+++ b/bd_analitico/esus-backups/impulso_previne_dados_nominais/views_materializadas/painel_citopatologico_lista_nominal.sql
@@ -300,7 +300,7 @@ AS WITH dados_anonimizados_demo_vicosa AS (
             COALESCE(tb1.estabelecimento_nome_cadastro, tb1.estabelecimento_nome_ultimo_atendimento) AS estabelecimento_nome,
             COALESCE(tb1.equipe_ine_cadastro, tb1.equipe_ine_ultimo_atendimento) AS equipe_ine,
             impulso_previne_dados_nominais.equipe_ine(tb1.municipio_id_sus::text, COALESCE(tb1.equipe_ine_cadastro, tb1.equipe_ine_ultimo_atendimento)::text) AS ine_master,
-            impulso_previne_dados_nominais.equipe_ine(tb1.municipio_id_sus::text, COALESCE(tb1.equipe_nome_cadastro, tb1.equipe_nome_ultimo_atendimento)::text) AS equipe_nome,
+            COALESCE(tb1.equipe_nome_cadastro, tb1.equipe_nome_ultimo_atendimento, 'SEM EQUIPE'::character varying) AS equipe_nome,
                 CASE
                     WHEN tb1.status_exame::text = 'exame_em_dia'::text THEN 12
                     WHEN tb1.status_exame::text = 'exame_nunca_realizado'::text THEN 13

--- a/bd_analitico/esus-backups/impulso_previne_dados_nominais/views_materializadas/painel_citopatologico_lista_nominal.sql
+++ b/bd_analitico/esus-backups/impulso_previne_dados_nominais/views_materializadas/painel_citopatologico_lista_nominal.sql
@@ -1,3 +1,4 @@
+-- impulso_previne_dados_nominais.painel_citopatologico_lista_nominal source
 
 CREATE MATERIALIZED VIEW impulso_previne_dados_nominais.painel_citopatologico_lista_nominal
 TABLESPACE pg_default
@@ -66,10 +67,9 @@ AS WITH dados_anonimizados_demo_vicosa AS (
                     tb1_1.acs_nome_visita,
                     tb1_1.criacao_data
                    FROM impulso_previne_dados_nominais.lista_nominal_citopatologico_unificada tb1_1
-                  WHERE tb1_1.municipio_id_sus::text = '317130'::text
-                  and tb1_1.equipe_ine_ultimo_atendimento is not null and tb1_1.equipe_ine_cadastro is not null ) res
-             JOIN configuracoes.nomes_ficticios_citopatologico nomes ON res.seq = nomes.seq
-             JOIN configuracoes.nomes_ficticios_gestantes nomes2 ON res.seq = nomes2.seq
+                  WHERE tb1_1.municipio_id_sus::text = '317130'::text AND tb1_1.equipe_ine_ultimo_atendimento IS NOT NULL AND tb1_1.equipe_ine_ultimo_atendimento::text <> '-'::text AND tb1_1.equipe_ine_cadastro IS NOT NULL AND tb1_1.equipe_ine_cadastro::text <> '-'::text AND tb1_1.equipe_nome_ultimo_atendimento IS NOT NULL AND (tb1_1.equipe_nome_ultimo_atendimento::text <> ALL (ARRAY['EMAD'::character varying, 'EAPP DE SAUDE VICOSA'::character varying, 'ESF BOM JESUS III'::character varying, 'EMULTI SAO JOSE CIDADE NOVA BA'::character varying, 'EMAD'::character varying, 'EMULTI SAO JOSE DO TRIUNFO'::character varying, 'EMULTI BOM JESUS'::character varying]::text[])) AND tb1_1.equipe_nome_cadastro IS NOT NULL AND tb1_1.equipe_nome_cadastro::text <> 'EMAD'::text) res
+             LEFT JOIN configuracoes.nomes_ficticios_citopatologico nomes ON res.seq = nomes.seq
+             LEFT JOIN configuracoes.nomes_ficticios_hipertensos nomes2 ON res.seq = nomes2.seq
         ), dados_anonimizados_impulsolandia AS (
          SELECT '111111'::character varying AS municipio_id_sus,
             res.quadrimestre_atual,
@@ -135,8 +135,7 @@ AS WITH dados_anonimizados_demo_vicosa AS (
                     tb1_1.acs_nome_visita,
                     tb1_1.criacao_data
                    FROM impulso_previne_dados_nominais.lista_nominal_citopatologico_unificada tb1_1
-                  WHERE tb1_1.municipio_id_sus::text = '317130'::text
-                  and tb1_1.equipe_ine_ultimo_atendimento is not null and tb1_1.equipe_ine_cadastro is not null ) res
+                  WHERE tb1_1.municipio_id_sus::text = '317130'::text) res
              JOIN configuracoes.nomes_ficticios_citopatologico nomes ON res.seq = nomes.seq
              JOIN configuracoes.nomes_ficticios_gestantes nomes2 ON res.seq = nomes2.seq
         ), dados_transmissoes_recentes AS (

--- a/bd_analitico/esus-backups/impulso_previne_dados_nominais/views_materializadas/painel_citopatologico_lista_nominal.sql
+++ b/bd_analitico/esus-backups/impulso_previne_dados_nominais/views_materializadas/painel_citopatologico_lista_nominal.sql
@@ -65,8 +65,8 @@ AS WITH dados_anonimizados_demo_vicosa AS (
                     tb1_1.acs_nome_ultimo_atendimento,
                     tb1_1.acs_nome_visita,
                     tb1_1.criacao_data
-                   FROM dados_nominais_mg_vicosa.lista_nominal_citopatologico tb1_1
-                   where tb1_1.equipe_ine_cadastro is not null and tb1_1.equipe_ine_ultimo_atendimento is not null) res
+                   FROM impulso_previne_dados_nominais.lista_nominal_citopatologico_unificada tb1_1
+                   where tb1_1.municipio_id_sus::text = '317130'::text) res
              JOIN configuracoes.nomes_ficticios_citopatologico nomes ON res.seq = nomes.seq
              JOIN configuracoes.nomes_ficticios_gestantes nomes2 ON res.seq = nomes2.seq
         ), dados_anonimizados_impulsolandia AS (
@@ -133,8 +133,8 @@ AS WITH dados_anonimizados_demo_vicosa AS (
                     tb1_1.acs_nome_ultimo_atendimento,
                     tb1_1.acs_nome_visita,
                     tb1_1.criacao_data
-                   FROM dados_nominais_mg_vicosa.lista_nominal_citopatologico tb1_1
-                   where tb1_1.equipe_ine_cadastro is not null and tb1_1.equipe_ine_ultimo_atendimento is not null ) res
+                   FROM impulso_previne_dados_nominais.lista_nominal_citopatologico_unificada tb1_1
+                   where tb1_1.municipio_id_sus::text = '317130'::text) res
              JOIN configuracoes.nomes_ficticios_citopatologico nomes ON res.seq = nomes.seq
              JOIN configuracoes.nomes_ficticios_gestantes nomes2 ON res.seq = nomes2.seq
         ), dados_transmissoes_recentes AS (

--- a/bd_analitico/esus-backups/impulso_previne_dados_nominais/views_materializadas/painel_enfermeiras_lista_nominal_diabeticos.sql
+++ b/bd_analitico/esus-backups/impulso_previne_dados_nominais/views_materializadas/painel_enfermeiras_lista_nominal_diabeticos.sql
@@ -65,7 +65,8 @@ AS WITH dados_anonimizados_demo_vicosa AS (
                     tb1_1.criacao_data,
                     tb1_1.atualizacao_data
                    FROM impulso_previne_dados_nominais.lista_nominal_diabeticos_unificada tb1_1
-                   where tb1_1.municipio_id_sus::text = '317130'::text) res
+                  WHERE tb1_1.municipio_id_sus::text = '317130'::text
+                  and tb1_1.equipe_ine_atendimento is not null and tb1_1.equipe_ine_cadastro is not null) res
              JOIN configuracoes.nomes_ficticios_diabeticos nomes ON res.seq = nomes.seq
              JOIN configuracoes.nomes_ficticios_hipertensos nomes2 ON res.seq = nomes2.seq
         ), dados_anonimizados_impulsolandia AS (
@@ -132,7 +133,8 @@ AS WITH dados_anonimizados_demo_vicosa AS (
                     tb1_1.criacao_data,
                     tb1_1.atualizacao_data
                    FROM impulso_previne_dados_nominais.lista_nominal_diabeticos_unificada tb1_1
-                   where tb1_1.municipio_id_sus::text = '317130'::text) res
+                  WHERE tb1_1.municipio_id_sus::text = '317130'::text
+                  and tb1_1.equipe_ine_atendimento is not null and tb1_1.equipe_ine_cadastro is not null) res
              JOIN configuracoes.nomes_ficticios_diabeticos nomes ON res.seq = nomes.seq
              JOIN configuracoes.nomes_ficticios_hipertensos nomes2 ON res.seq = nomes2.seq
         ), dados_transmissoes_recentes AS (
@@ -175,7 +177,7 @@ AS WITH dados_anonimizados_demo_vicosa AS (
             dados_anonimizados_demo_vicosa.dt_solicitacao_hemoglobina_glicada_mais_recente,
             dados_anonimizados_demo_vicosa.realizou_consulta_ultimos_6_meses,
             dados_anonimizados_demo_vicosa.dt_consulta_mais_recente,
-            dados_anonimizados_demo_vicosa.co_seq_fat_cidadao_pec::text AS co_seq_fat_cidadao_pec,
+            dados_anonimizados_demo_vicosa.co_seq_fat_cidadao_pec,
             dados_anonimizados_demo_vicosa.cidadao_cpf,
             dados_anonimizados_demo_vicosa.cidadao_cns,
             dados_anonimizados_demo_vicosa.cidadao_nome,
@@ -207,7 +209,7 @@ AS WITH dados_anonimizados_demo_vicosa AS (
             dados_anonimizados_impulsolandia.dt_solicitacao_hemoglobina_glicada_mais_recente,
             dados_anonimizados_impulsolandia.realizou_consulta_ultimos_6_meses,
             dados_anonimizados_impulsolandia.dt_consulta_mais_recente,
-            dados_anonimizados_impulsolandia.co_seq_fat_cidadao_pec::text AS co_seq_fat_cidadao_pec,
+            dados_anonimizados_impulsolandia.co_seq_fat_cidadao_pec,
             dados_anonimizados_impulsolandia.cidadao_cpf,
             dados_anonimizados_impulsolandia.cidadao_cns,
             dados_anonimizados_impulsolandia.cidadao_nome,

--- a/bd_analitico/esus-backups/impulso_previne_dados_nominais/views_materializadas/painel_enfermeiras_lista_nominal_diabeticos.sql
+++ b/bd_analitico/esus-backups/impulso_previne_dados_nominais/views_materializadas/painel_enfermeiras_lista_nominal_diabeticos.sql
@@ -64,7 +64,8 @@ AS WITH dados_anonimizados_demo_vicosa AS (
                     tb1_1.se_mudou,
                     tb1_1.criacao_data,
                     tb1_1.atualizacao_data
-                   FROM dados_nominais_mg_vicosa.lista_nominal_diabeticos tb1_1) res
+                   FROM dados_nominais_mg_vicosa.lista_nominal_diabeticos tb1_1
+                  where tb1_1.equipe_ine_atendimento is not null and tb1_1.equipe_ine_cadastro is not null) res
              JOIN configuracoes.nomes_ficticios_diabeticos nomes ON res.seq = nomes.seq
              JOIN configuracoes.nomes_ficticios_hipertensos nomes2 ON res.seq = nomes2.seq
         ), dados_anonimizados_impulsolandia AS (
@@ -130,7 +131,8 @@ AS WITH dados_anonimizados_demo_vicosa AS (
                     tb1_1.se_mudou,
                     tb1_1.criacao_data,
                     tb1_1.atualizacao_data
-                   FROM dados_nominais_mg_vicosa.lista_nominal_diabeticos tb1_1) res
+                   FROM dados_nominais_mg_vicosa.lista_nominal_diabeticos tb1_1
+                   where tb1_1.equipe_ine_atendimento is not null and tb1_1.equipe_ine_cadastro is not null) res
              JOIN configuracoes.nomes_ficticios_diabeticos nomes ON res.seq = nomes.seq
              JOIN configuracoes.nomes_ficticios_hipertensos nomes2 ON res.seq = nomes2.seq
         ), dados_transmissoes_recentes AS (
@@ -262,109 +264,144 @@ AS WITH dados_anonimizados_demo_vicosa AS (
             dados_transmissoes_recentes.se_mudou,
             dados_transmissoes_recentes.criacao_data
            FROM dados_transmissoes_recentes
+        ), data_registro_producao AS (
+         SELECT une_as_bases.municipio_id_sus,
+            impulso_previne_dados_nominais.equipe_ine(une_as_bases.municipio_id_sus::text, COALESCE(une_as_bases.equipe_ine_cadastro, une_as_bases.equipe_ine_atendimento)) AS equipe_ine_cadastro,
+            max(GREATEST(une_as_bases.dt_solicitacao_hemoglobina_glicada_mais_recente::date, une_as_bases.dt_consulta_mais_recente, une_as_bases.data_ultimo_cadastro, une_as_bases.dt_ultima_consulta)) AS dt_registro_producao_mais_recente,
+            min(LEAST(une_as_bases.dt_solicitacao_hemoglobina_glicada_mais_recente::date, une_as_bases.dt_consulta_mais_recente, une_as_bases.data_ultimo_cadastro, une_as_bases.dt_ultima_consulta)) AS dt_registro_producao_mais_antigo
+           FROM une_as_bases
+          GROUP BY une_as_bases.municipio_id_sus, (impulso_previne_dados_nominais.equipe_ine(une_as_bases.municipio_id_sus::text, COALESCE(une_as_bases.equipe_ine_cadastro, une_as_bases.equipe_ine_atendimento)))
+        ), tabela_aux AS (
+         SELECT tb1.municipio_id_sus,
+            concat(tb2.nome, ' - ', tb2.uf_sigla) AS municipio_uf,
+            tb1.quadrimestre_atual,
+            tb1.realizou_solicitacao_hemoglobina_ultimos_6_meses,
+            tb1.dt_solicitacao_hemoglobina_glicada_mais_recente,
+            tb1.realizou_consulta_ultimos_6_meses,
+            tb1.dt_consulta_mais_recente,
+                CASE
+                    WHEN tb1.realizou_solicitacao_hemoglobina_ultimos_6_meses THEN 'Em dia'::text
+                    ELSE impulso_previne_dados_nominais.prazo_proximo_dia()
+                END AS prazo_proxima_solicitacao_hemoglobina,
+                CASE
+                    WHEN tb1.realizou_consulta_ultimos_6_meses THEN 'Em dia'::text
+                    ELSE impulso_previne_dados_nominais.prazo_proximo_dia()
+                END AS prazo_proxima_consulta,
+                CASE
+                    WHEN tb1.realizou_solicitacao_hemoglobina_ultimos_6_meses AND tb1.realizou_consulta_ultimos_6_meses THEN 1
+                    ELSE 0
+                END AS consulta_e_solicitacao_hemoglobina_em_dia,
+                CASE
+                    WHEN tb1.realizou_consulta_ultimos_6_meses IS FALSE OR tb1.realizou_solicitacao_hemoglobina_ultimos_6_meses IS FALSE THEN 'Não está em dia'::text
+                    WHEN tb1.realizou_consulta_ultimos_6_meses AND tb1.realizou_solicitacao_hemoglobina_ultimos_6_meses THEN 'Em dia'::text
+                    ELSE NULL::text
+                END AS status_em_dia,
+                CASE
+                    WHEN tb1.realizou_solicitacao_hemoglobina_ultimos_6_meses AND tb1.realizou_consulta_ultimos_6_meses THEN 'Em dia com consulta e solicitação de hemoglobina'::text
+                    WHEN tb1.realizou_solicitacao_hemoglobina_ultimos_6_meses IS FALSE AND tb1.realizou_consulta_ultimos_6_meses IS FALSE THEN 'Nada em dia'::text
+                    WHEN tb1.realizou_solicitacao_hemoglobina_ultimos_6_meses AND tb1.realizou_consulta_ultimos_6_meses IS FALSE THEN 'Apenas solicitação de hemoglobina em dia'::text
+                    WHEN tb1.realizou_solicitacao_hemoglobina_ultimos_6_meses IS FALSE AND tb1.realizou_consulta_ultimos_6_meses THEN 'Apenas consulta em dia'::text
+                    ELSE NULL::text
+                END AS status_usuario,
+                CASE
+                    WHEN tb1.possui_diabetes_diagnosticada THEN 'Diagnóstico Clínico'::text
+                    WHEN tb1.possui_diabetes_autoreferida AND tb1.possui_diabetes_diagnosticada IS FALSE THEN 'Autorreferida'::text
+                    WHEN tb1.possui_diabetes_autoreferida AND tb1.possui_diabetes_diagnosticada IS NULL THEN 'Autorreferida'::text
+                    ELSE NULL::text
+                END AS identificacao_condicao_diabetes,
+            tb1.cidadao_cpf,
+                CASE
+                    WHEN tb1.cidadao_cpf IS NULL THEN tb1.dt_nascimento::text::character varying::text
+                    ELSE tb1.cidadao_cpf
+                END AS cidadao_cpf_dt_nascimento,
+            tb1.cidadao_cns,
+            tb1.cidadao_nome,
+            tb1.cidadao_nome_social,
+            tb1.cidadao_sexo,
+            tb1.dt_nascimento,
+            date_part('year'::text, age(CURRENT_DATE::timestamp with time zone, tb1.dt_nascimento::timestamp with time zone))::integer AS cidadao_idade,
+                CASE
+                    WHEN date_part('year'::text, age(CURRENT_DATE::timestamp with time zone, tb1.dt_nascimento::timestamp with time zone)) <= 40::double precision THEN '0 a 40 anos'::text
+                    WHEN date_part('year'::text, age(CURRENT_DATE::timestamp with time zone, tb1.dt_nascimento::timestamp with time zone)) > 40::double precision AND date_part('year'::text, age(CURRENT_DATE::timestamp with time zone, tb1.dt_nascimento::timestamp with time zone)) <= 49::double precision THEN '41 a 49 anos'::text
+                    WHEN date_part('year'::text, age(CURRENT_DATE::timestamp with time zone, tb1.dt_nascimento::timestamp with time zone)) > 49::double precision AND date_part('year'::text, age(CURRENT_DATE::timestamp with time zone, tb1.dt_nascimento::timestamp with time zone)) <= 59::double precision THEN '50 a 59 anos'::text
+                    WHEN date_part('year'::text, age(CURRENT_DATE::timestamp with time zone, tb1.dt_nascimento::timestamp with time zone)) > 59::double precision AND date_part('year'::text, age(CURRENT_DATE::timestamp with time zone, tb1.dt_nascimento::timestamp with time zone)) <= 70::double precision THEN '60 a 70 anos'::text
+                    WHEN tb1.dt_nascimento IS NULL THEN NULL::text
+                    ELSE '70 anos ou mais'::text
+                END AS cidadao_faixa_etaria,
+            tb1.estabelecimento_cnes_atendimento,
+            tb1.estabelecimento_cnes_cadastro,
+            tb1.estabelecimento_nome_atendimento,
+            tb1.estabelecimento_nome_cadastro,
+            tb1.equipe_ine_atendimento,
+            impulso_previne_dados_nominais.equipe_ine(tb1.municipio_id_sus::text, COALESCE(tb1.equipe_ine_cadastro, tb1.equipe_ine_atendimento)) AS equipe_ine_cadastro,
+            tb1.equipe_nome_atendimento,
+            impulso_previne_dados_nominais.equipe_ine(tb1.municipio_id_sus::text, COALESCE(tb1.equipe_nome_cadastro, tb1.equipe_nome_atendimento)) AS equipe_nome_cadastro,
+            tb1.acs_nome_cadastro,
+            tb1.acs_nome_visita,
+            tb1.possui_diabetes_autoreferida AS possui_diabetes_autorreferida,
+            tb1.possui_diabetes_diagnosticada,
+                CASE
+                    WHEN tb1.possui_diabetes_autoreferida AND tb1.possui_diabetes_diagnosticada IS FALSE THEN 1
+                    WHEN tb1.possui_diabetes_autoreferida AND tb1.possui_diabetes_diagnosticada IS NULL THEN 1
+                    ELSE 0
+                END AS apenas_autorreferida,
+                CASE
+                    WHEN tb1.possui_diabetes_diagnosticada THEN 1
+                    ELSE 0
+                END AS diagnostico_clinico,
+            tb1.data_ultimo_cadastro,
+            tb1.dt_ultima_consulta,
+            tb1.se_faleceu,
+            tb1.se_mudou,
+            tb1.criacao_data,
+            CURRENT_TIMESTAMP AS atualizacao_data
+           FROM une_as_bases tb1
+             LEFT JOIN listas_de_codigos.municipios tb2 ON tb1.municipio_id_sus::bpchar = tb2.id_sus
+          WHERE COALESCE(tb1.se_faleceu, 0) <> 1
         )
-, data_registro_producao AS (
-    SELECT 
-        municipio_id_sus,
-    	impulso_previne_dados_nominais.equipe_ine(municipio_id_sus::text, COALESCE(equipe_ine_cadastro, equipe_ine_atendimento)) AS equipe_ine_cadastro,
-        MAX(GREATEST(dt_solicitacao_hemoglobina_glicada_mais_recente::date,dt_consulta_mais_recente::date,data_ultimo_cadastro::date,dt_ultima_consulta::date)) AS dt_registro_producao_mais_recente,
-        MIN(LEAST(dt_solicitacao_hemoglobina_glicada_mais_recente::date,dt_consulta_mais_recente::date,data_ultimo_cadastro::date,dt_ultima_consulta::date)) AS dt_registro_producao_mais_antigo
-    FROM une_as_bases
-    GROUP BY 1, 2
-)
-, tabela_aux as (          
- SELECT tb1.municipio_id_sus,
-    concat(tb2.nome, ' - ', tb2.uf_sigla) AS municipio_uf,
-    tb1.quadrimestre_atual,
-    tb1.realizou_solicitacao_hemoglobina_ultimos_6_meses,
-    tb1.dt_solicitacao_hemoglobina_glicada_mais_recente,
-    tb1.realizou_consulta_ultimos_6_meses,
-    tb1.dt_consulta_mais_recente,
-        CASE
-            WHEN tb1.realizou_solicitacao_hemoglobina_ultimos_6_meses THEN 'Em dia'::text
-            ELSE impulso_previne_dados_nominais.prazo_proximo_dia()
-        END AS prazo_proxima_solicitacao_hemoglobina,
-        CASE
-            WHEN tb1.realizou_consulta_ultimos_6_meses THEN 'Em dia'::text
-            ELSE impulso_previne_dados_nominais.prazo_proximo_dia()
-        END AS prazo_proxima_consulta,
-        CASE
-            WHEN tb1.realizou_solicitacao_hemoglobina_ultimos_6_meses AND tb1.realizou_consulta_ultimos_6_meses THEN 1
-            ELSE 0
-        END AS consulta_e_solicitacao_hemoglobina_em_dia,
-        CASE
-            WHEN tb1.realizou_consulta_ultimos_6_meses IS FALSE OR tb1.realizou_solicitacao_hemoglobina_ultimos_6_meses IS FALSE THEN 'Não está em dia'::text
-            WHEN tb1.realizou_consulta_ultimos_6_meses AND tb1.realizou_solicitacao_hemoglobina_ultimos_6_meses THEN 'Em dia'::text
-            ELSE NULL::text
-        END AS status_em_dia,
-        CASE
-            WHEN tb1.realizou_solicitacao_hemoglobina_ultimos_6_meses AND tb1.realizou_consulta_ultimos_6_meses THEN 'Em dia com consulta e solicitação de hemoglobina'::text
-            WHEN tb1.realizou_solicitacao_hemoglobina_ultimos_6_meses IS FALSE AND tb1.realizou_consulta_ultimos_6_meses IS FALSE THEN 'Nada em dia'::text
-            WHEN tb1.realizou_solicitacao_hemoglobina_ultimos_6_meses AND tb1.realizou_consulta_ultimos_6_meses IS FALSE THEN 'Apenas solicitação de hemoglobina em dia'::text
-            WHEN tb1.realizou_solicitacao_hemoglobina_ultimos_6_meses IS FALSE AND tb1.realizou_consulta_ultimos_6_meses THEN 'Apenas consulta em dia'::text
-            ELSE NULL::text
-        END AS status_usuario,
-        CASE
-            WHEN tb1.possui_diabetes_diagnosticada THEN 'Diagnóstico Clínico'::text
-            WHEN tb1.possui_diabetes_autoreferida AND tb1.possui_diabetes_diagnosticada IS FALSE THEN 'Autorreferida'::text
-            WHEN tb1.possui_diabetes_autoreferida AND tb1.possui_diabetes_diagnosticada IS NULL THEN 'Autorreferida'::text
-            ELSE NULL::text
-        END AS identificacao_condicao_diabetes,
-    tb1.cidadao_cpf,
-        CASE
-            WHEN tb1.cidadao_cpf IS NULL THEN tb1.dt_nascimento::text::character varying::text
-            ELSE tb1.cidadao_cpf
-        END AS cidadao_cpf_dt_nascimento,
-    tb1.cidadao_cns,
-    tb1.cidadao_nome,
-    tb1.cidadao_nome_social,
-    tb1.cidadao_sexo,
-    tb1.dt_nascimento,
-    date_part('year'::text, age(CURRENT_DATE::timestamp with time zone, tb1.dt_nascimento::timestamp with time zone))::integer AS cidadao_idade,
-        CASE
-            WHEN date_part('year'::text, age(CURRENT_DATE::timestamp with time zone, tb1.dt_nascimento::timestamp with time zone)) <= 40::double precision THEN '0 a 40 anos'::text
-            WHEN date_part('year'::text, age(CURRENT_DATE::timestamp with time zone, tb1.dt_nascimento::timestamp with time zone)) > 40::double precision AND date_part('year'::text, age(CURRENT_DATE::timestamp with time zone, tb1.dt_nascimento::timestamp with time zone)) <= 49::double precision THEN '41 a 49 anos'::text
-            WHEN date_part('year'::text, age(CURRENT_DATE::timestamp with time zone, tb1.dt_nascimento::timestamp with time zone)) > 49::double precision AND date_part('year'::text, age(CURRENT_DATE::timestamp with time zone, tb1.dt_nascimento::timestamp with time zone)) <= 59::double precision THEN '50 a 59 anos'::text
-            WHEN date_part('year'::text, age(CURRENT_DATE::timestamp with time zone, tb1.dt_nascimento::timestamp with time zone)) > 59::double precision AND date_part('year'::text, age(CURRENT_DATE::timestamp with time zone, tb1.dt_nascimento::timestamp with time zone)) <= 70::double precision THEN '60 a 70 anos'::text
-            WHEN tb1.dt_nascimento IS NULL THEN NULL::text
-            ELSE '70 anos ou mais'::text
-        END AS cidadao_faixa_etaria,
-    tb1.estabelecimento_cnes_atendimento,
-    tb1.estabelecimento_cnes_cadastro,
-    tb1.estabelecimento_nome_atendimento,
-    tb1.estabelecimento_nome_cadastro,
-    tb1.equipe_ine_atendimento,
-    impulso_previne_dados_nominais.equipe_ine(tb1.municipio_id_sus::text, COALESCE(tb1.equipe_ine_cadastro, tb1.equipe_ine_atendimento)) AS equipe_ine_cadastro,
-    tb1.equipe_nome_atendimento,
-    impulso_previne_dados_nominais.equipe_ine(tb1.municipio_id_sus::text, COALESCE(tb1.equipe_nome_cadastro, tb1.equipe_nome_atendimento)) AS equipe_nome_cadastro,
-    tb1.acs_nome_cadastro,
-    tb1.acs_nome_visita,
-    tb1.possui_diabetes_autoreferida AS possui_diabetes_autorreferida,
-    tb1.possui_diabetes_diagnosticada,
-        CASE
-            WHEN tb1.possui_diabetes_autoreferida AND tb1.possui_diabetes_diagnosticada IS FALSE THEN 1
-            WHEN tb1.possui_diabetes_autoreferida AND tb1.possui_diabetes_diagnosticada IS NULL THEN 1
-            ELSE 0
-        END AS apenas_autorreferida,
-        CASE
-            WHEN tb1.possui_diabetes_diagnosticada THEN 1
-            ELSE 0
-        END AS diagnostico_clinico,
-    tb1.data_ultimo_cadastro,
-    tb1.dt_ultima_consulta,
-    tb1.se_faleceu,
-    tb1.se_mudou,
-    tb1.criacao_data,
-    CURRENT_TIMESTAMP AS atualizacao_data
-   FROM une_as_bases tb1
-     LEFT JOIN listas_de_codigos.municipios tb2 ON tb1.municipio_id_sus::bpchar = tb2.id_sus
-  WHERE COALESCE(tb1.se_faleceu, 0) <> 1
-  )
-SELECT
-    tabela_aux.*,
+ SELECT tabela_aux.municipio_id_sus,
+    tabela_aux.municipio_uf,
+    tabela_aux.quadrimestre_atual,
+    tabela_aux.realizou_solicitacao_hemoglobina_ultimos_6_meses,
+    tabela_aux.dt_solicitacao_hemoglobina_glicada_mais_recente,
+    tabela_aux.realizou_consulta_ultimos_6_meses,
+    tabela_aux.dt_consulta_mais_recente,
+    tabela_aux.prazo_proxima_solicitacao_hemoglobina,
+    tabela_aux.prazo_proxima_consulta,
+    tabela_aux.consulta_e_solicitacao_hemoglobina_em_dia,
+    tabela_aux.status_em_dia,
+    tabela_aux.status_usuario,
+    tabela_aux.identificacao_condicao_diabetes,
+    tabela_aux.cidadao_cpf,
+    tabela_aux.cidadao_cpf_dt_nascimento,
+    tabela_aux.cidadao_cns,
+    tabela_aux.cidadao_nome,
+    tabela_aux.cidadao_nome_social,
+    tabela_aux.cidadao_sexo,
+    tabela_aux.dt_nascimento,
+    tabela_aux.cidadao_idade,
+    tabela_aux.cidadao_faixa_etaria,
+    tabela_aux.estabelecimento_cnes_atendimento,
+    tabela_aux.estabelecimento_cnes_cadastro,
+    tabela_aux.estabelecimento_nome_atendimento,
+    tabela_aux.estabelecimento_nome_cadastro,
+    tabela_aux.equipe_ine_atendimento,
+    tabela_aux.equipe_ine_cadastro,
+    tabela_aux.equipe_nome_atendimento,
+    tabela_aux.equipe_nome_cadastro,
+    tabela_aux.acs_nome_cadastro,
+    tabela_aux.acs_nome_visita,
+    tabela_aux.possui_diabetes_autorreferida,
+    tabela_aux.possui_diabetes_diagnosticada,
+    tabela_aux.apenas_autorreferida,
+    tabela_aux.diagnostico_clinico,
+    tabela_aux.data_ultimo_cadastro,
+    tabela_aux.dt_ultima_consulta,
+    tabela_aux.se_faleceu,
+    tabela_aux.se_mudou,
+    tabela_aux.criacao_data,
+    tabela_aux.atualizacao_data,
     drp.dt_registro_producao_mais_recente
-FROM tabela_aux
-LEFT JOIN data_registro_producao drp 
-    ON drp.municipio_id_sus = tabela_aux.municipio_id_sus
-    AND drp.equipe_ine_cadastro = tabela_aux.equipe_ine_cadastro
+   FROM tabela_aux
+     LEFT JOIN data_registro_producao drp ON drp.municipio_id_sus::text = tabela_aux.municipio_id_sus::text AND drp.equipe_ine_cadastro = tabela_aux.equipe_ine_cadastro
 WITH DATA;

--- a/bd_analitico/esus-backups/impulso_previne_dados_nominais/views_materializadas/painel_enfermeiras_lista_nominal_diabeticos.sql
+++ b/bd_analitico/esus-backups/impulso_previne_dados_nominais/views_materializadas/painel_enfermeiras_lista_nominal_diabeticos.sql
@@ -64,8 +64,8 @@ AS WITH dados_anonimizados_demo_vicosa AS (
                     tb1_1.se_mudou,
                     tb1_1.criacao_data,
                     tb1_1.atualizacao_data
-                   FROM dados_nominais_mg_vicosa.lista_nominal_diabeticos tb1_1
-                  where tb1_1.equipe_ine_atendimento is not null and tb1_1.equipe_ine_cadastro is not null) res
+                   FROM impulso_previne_dados_nominais.lista_nominal_diabeticos_unificada tb1_1
+                   where tb1_1.municipio_id_sus::text = '317130'::text) res
              JOIN configuracoes.nomes_ficticios_diabeticos nomes ON res.seq = nomes.seq
              JOIN configuracoes.nomes_ficticios_hipertensos nomes2 ON res.seq = nomes2.seq
         ), dados_anonimizados_impulsolandia AS (
@@ -131,8 +131,8 @@ AS WITH dados_anonimizados_demo_vicosa AS (
                     tb1_1.se_mudou,
                     tb1_1.criacao_data,
                     tb1_1.atualizacao_data
-                   FROM dados_nominais_mg_vicosa.lista_nominal_diabeticos tb1_1
-                   where tb1_1.equipe_ine_atendimento is not null and tb1_1.equipe_ine_cadastro is not null) res
+                   FROM impulso_previne_dados_nominais.lista_nominal_diabeticos_unificada tb1_1
+                   where tb1_1.municipio_id_sus::text = '317130'::text) res
              JOIN configuracoes.nomes_ficticios_diabeticos nomes ON res.seq = nomes.seq
              JOIN configuracoes.nomes_ficticios_hipertensos nomes2 ON res.seq = nomes2.seq
         ), dados_transmissoes_recentes AS (

--- a/bd_analitico/esus-backups/impulso_previne_dados_nominais/views_materializadas/painel_enfermeiras_lista_nominal_hipertensos.sql
+++ b/bd_analitico/esus-backups/impulso_previne_dados_nominais/views_materializadas/painel_enfermeiras_lista_nominal_hipertensos.sql
@@ -64,7 +64,8 @@ AS WITH dados_anonimizados_demo_vicosa AS (
                     tb1_1.se_mudou,
                     tb1_1.criacao_data
                    FROM impulso_previne_dados_nominais.lista_nominal_hipertensos_unificada tb1_1
-                   where tb1_1.municipio_id_sus::text = '317130'::text) res
+                   where tb1_1.municipio_id_sus::text = '317130'::text
+                   and tb1_1.equipe_ine_atendimento is not null and tb1_1.equipe_ine_cadastro is not null) res
              JOIN configuracoes.nomes_ficticios_hipertensos nomes ON res.seq = nomes.seq
              JOIN configuracoes.nomes_ficticios_diabeticos nomes2 ON res.seq = nomes2.seq
         ), dados_anonimizados_impulsolandia AS (
@@ -130,7 +131,8 @@ AS WITH dados_anonimizados_demo_vicosa AS (
                     tb1_1.se_mudou,
                     tb1_1.criacao_data
                    FROM impulso_previne_dados_nominais.lista_nominal_hipertensos_unificada tb1_1
-                   where tb1_1.municipio_id_sus::text = '317130'::text) res
+                   where tb1_1.municipio_id_sus::text = '317130'::text
+                   and tb1_1.equipe_ine_atendimento is not null and tb1_1.equipe_ine_cadastro is not null) res
              JOIN configuracoes.nomes_ficticios_hipertensos nomes ON res.seq = nomes.seq
              JOIN configuracoes.nomes_ficticios_diabeticos nomes2 ON res.seq = nomes2.seq
         ), dados_transmissoes_recentes AS (

--- a/bd_analitico/esus-backups/impulso_previne_dados_nominais/views_materializadas/painel_enfermeiras_lista_nominal_hipertensos.sql
+++ b/bd_analitico/esus-backups/impulso_previne_dados_nominais/views_materializadas/painel_enfermeiras_lista_nominal_hipertensos.sql
@@ -63,8 +63,8 @@ AS WITH dados_anonimizados_demo_vicosa AS (
                     tb1_1.se_faleceu,
                     tb1_1.se_mudou,
                     tb1_1.criacao_data
-                   FROM dados_nominais_mg_vicosa.lista_nominal_hipertensos tb1_1
-                    where tb1_1.equipe_ine_atendimento is not null and tb1_1.equipe_ine_cadastro is not null) res
+                   FROM impulso_previne_dados_nominais.lista_nominal_hipertensos_unificada tb1_1
+                   where tb1_1.municipio_id_sus::text = '317130'::text) res
              JOIN configuracoes.nomes_ficticios_hipertensos nomes ON res.seq = nomes.seq
              JOIN configuracoes.nomes_ficticios_diabeticos nomes2 ON res.seq = nomes2.seq
         ), dados_anonimizados_impulsolandia AS (
@@ -129,8 +129,8 @@ AS WITH dados_anonimizados_demo_vicosa AS (
                     tb1_1.se_faleceu,
                     tb1_1.se_mudou,
                     tb1_1.criacao_data
-                   FROM dados_nominais_mg_vicosa.lista_nominal_hipertensos tb1_1
-                    where tb1_1.equipe_ine_atendimento is not null and tb1_1.equipe_ine_cadastro is not null) res
+                   FROM impulso_previne_dados_nominais.lista_nominal_hipertensos_unificada tb1_1
+                   where tb1_1.municipio_id_sus::text = '317130'::text) res
              JOIN configuracoes.nomes_ficticios_hipertensos nomes ON res.seq = nomes.seq
              JOIN configuracoes.nomes_ficticios_diabeticos nomes2 ON res.seq = nomes2.seq
         ), dados_transmissoes_recentes AS (

--- a/bd_analitico/esus-backups/impulso_previne_dados_nominais/views_materializadas/painel_gestantes_lista_nominal.sql
+++ b/bd_analitico/esus-backups/impulso_previne_dados_nominais/views_materializadas/painel_gestantes_lista_nominal.sql
@@ -268,43 +268,79 @@ AS WITH dados_anonimizados_demo_vicosa AS (
             COALESCE(tb1.gestante_documento_cpf, tb1.gestante_data_de_nascimento::text) AS cidadao_cpf_dt_nascimento,
             tb1.gestacao_data_dpp,
                 CASE
-                    WHEN date_part('month'::text, tb1.gestacao_data_dpp) >= 1::double precision AND date_part('month'::text, tb1.gestacao_data_dpp) <= 4::double precision THEN concat(date_part('year'::text, tb1.gestacao_data_dpp), '.Q1')
-                    WHEN date_part('month'::text, tb1.gestacao_data_dpp) >= 5::double precision AND date_part('month'::text, tb1.gestacao_data_dpp) <= 8::double precision THEN concat(date_part('year'::text, tb1.gestacao_data_dpp), '.Q2')
-                    WHEN date_part('month'::text, tb1.gestacao_data_dpp) >= 9::double precision AND date_part('month'::text, tb1.gestacao_data_dpp) <= 12::double precision THEN concat(date_part('year'::text, tb1.gestacao_data_dpp), '.Q3')
-                    ELSE 'sem DUM'::text
+                    WHEN date_part('month', tb1.gestacao_data_dpp) >= 1 AND date_part('month', tb1.gestacao_data_dpp) <= 4 THEN concat(date_part('year', tb1.gestacao_data_dpp), '.Q1')
+                    WHEN date_part('month', tb1.gestacao_data_dpp) >= 5 AND date_part('month', tb1.gestacao_data_dpp) <= 8 THEN concat(date_part('year', tb1.gestacao_data_dpp), '.Q2')
+                    WHEN date_part('month', tb1.gestacao_data_dpp) >= 9 AND date_part('month', tb1.gestacao_data_dpp) <= 12 THEN concat(date_part('year', tb1.gestacao_data_dpp), '.Q3')
+                    ELSE 'sem DUM'
                 END AS gestacao_quadrimestre,
                 CASE
-                    WHEN tb1.gestacao_data_dum IS NULL THEN NULL::integer
+                    WHEN tb1.gestacao_data_dum IS NULL 
+                        OR tb1.gestacao_data_dpp < (CASE -- Ou DPP é menor que a data de início do quadrimestre anterior
+                            WHEN date_part('month', CURRENT_DATE) >= 1 AND date_part('month', CURRENT_DATE) <= 4 THEN concat((date_part('year', CURRENT_DATE) - 1), '-09-01')::DATE
+                            WHEN date_part('month', CURRENT_DATE) >= 5 AND date_part('month', CURRENT_DATE) <= 8 THEN concat(date_part('year', CURRENT_DATE), '-01-01')::DATE
+                            WHEN date_part('month', CURRENT_DATE) >= 9 AND date_part('month', CURRENT_DATE) <= 12 THEN concat(date_part('year', CURRENT_DATE), '-05-01')::DATE
+                         END)
+                        THEN NULL::integer
                     ELSE tb1.gestacao_idade_gestacional_atual
                 END AS gestacao_idade_gestacional_atual,
                 CASE
-                    WHEN tb1.gestacao_data_dum IS NULL THEN NULL::integer
+                    WHEN tb1.gestacao_data_dum IS NULL 
+                        OR tb1.gestacao_data_dpp < (CASE -- Ou DPP é menor que a data de início do quadrimestre anterior
+                            WHEN date_part('month', CURRENT_DATE) >= 1 AND date_part('month', CURRENT_DATE) <= 4 THEN concat((date_part('year', CURRENT_DATE) - 1), '-09-01')::DATE
+                            WHEN date_part('month', CURRENT_DATE) >= 5 AND date_part('month', CURRENT_DATE) <= 8 THEN concat(date_part('year', CURRENT_DATE), '-01-01')::DATE
+                            WHEN date_part('month', CURRENT_DATE) >= 9 AND date_part('month', CURRENT_DATE) <= 12 THEN concat(date_part('year', CURRENT_DATE), '-05-01')::DATE
+                         END)                        
+                        THEN NULL::integer
                     ELSE tb1.gestacao_idade_gestacional_primeiro_atendimento
                 END AS gestacao_idade_gestacional_primeiro_atendimento,
             tb1.consulta_prenatal_ultima_data,
                 CASE
-                    WHEN tb1.gestacao_data_dum IS NULL THEN NULL::bigint
+                    WHEN tb1.gestacao_data_dum IS NULL 
+                        OR tb1.gestacao_data_dpp < (CASE -- Ou DPP é menor que a data de início do quadrimestre anterior
+                            WHEN date_part('month', CURRENT_DATE) >= 1 AND date_part('month', CURRENT_DATE) <= 4 THEN concat((date_part('year', CURRENT_DATE) - 1), '-09-01')::DATE
+                            WHEN date_part('month', CURRENT_DATE) >= 5 AND date_part('month', CURRENT_DATE) <= 8 THEN concat(date_part('year', CURRENT_DATE), '-01-01')::DATE
+                            WHEN date_part('month', CURRENT_DATE) >= 9 AND date_part('month', CURRENT_DATE) <= 12 THEN concat(date_part('year', CURRENT_DATE), '-05-01')::DATE
+                         END)     
+                        THEN NULL::bigint
                     ELSE tb1.consultas_pre_natal_validas
                 END AS consultas_pre_natal_validas,
                 CASE
-                    WHEN tb1.gestacao_data_dum IS NULL THEN 3
-                    WHEN tb1.atendimento_odontologico_realizado_valido THEN 1
-                    WHEN tb1.atendimento_odontologico_realizado_valido IS FALSE THEN 2
+                    WHEN tb1.gestacao_data_dum IS NULL 
+                        OR tb1.gestacao_data_dpp < (CASE -- Ou DPP é menor que a data de início do quadrimestre anterior
+                            WHEN date_part('month', CURRENT_DATE) >= 1 AND date_part('month', CURRENT_DATE) <= 4 THEN concat((date_part('year', CURRENT_DATE) - 1), '-09-01')::DATE
+                            WHEN date_part('month', CURRENT_DATE) >= 5 AND date_part('month', CURRENT_DATE) <= 8 THEN concat(date_part('year', CURRENT_DATE), '-01-01')::DATE
+                            WHEN date_part('month', CURRENT_DATE) >= 9 AND date_part('month', CURRENT_DATE) <= 12 THEN concat(date_part('year', CURRENT_DATE), '-05-01')::DATE
+                         END) 
+                         THEN 3 -- Retona '-' para gestantes sem DUM
+                    WHEN tb1.atendimento_odontologico_realizado_valido THEN 1 -- Atend. odontológico identificado
+                    WHEN tb1.atendimento_odontologico_realizado_valido IS FALSE THEN 2  -- Atend. odontológico não identificado
                     ELSE 0
                 END AS id_atendimento_odontologico,
                 CASE
-                    WHEN tb1.gestacao_data_dum IS NULL THEN 5
-                    WHEN tb1.exame_hiv_realizado_valido AND tb1.exame_sifilis_realizado_valido IS FALSE THEN 1
-                    WHEN tb1.exame_sifilis_realizado_valido AND tb1.exame_hiv_realizado_valido IS FALSE THEN 2
-                    WHEN tb1.exame_sifilis_realizado_valido IS FALSE AND tb1.exame_hiv_realizado_valido IS FALSE THEN 3
-                    WHEN tb1.exame_sifilis_realizado_valido AND tb1.exame_hiv_realizado_valido THEN 4
+                    WHEN tb1.gestacao_data_dum IS NULL 
+                        OR tb1.gestacao_data_dpp < (CASE -- Ou DPP é menor que a data de início do quadrimestre anterior
+                            WHEN date_part('month', CURRENT_DATE) >= 1 AND date_part('month', CURRENT_DATE) <= 4 THEN concat((date_part('year', CURRENT_DATE) - 1), '-09-01')::DATE
+                            WHEN date_part('month', CURRENT_DATE) >= 5 AND date_part('month', CURRENT_DATE) <= 8 THEN concat(date_part('year', CURRENT_DATE), '-01-01')::DATE
+                            WHEN date_part('month', CURRENT_DATE) >= 9 AND date_part('month', CURRENT_DATE) <= 12 THEN concat(date_part('year', CURRENT_DATE), '-05-01')::DATE
+                         END) 
+                         THEN 5 -- Retona '-' para gestantes sem DUM
+                    WHEN tb1.exame_hiv_realizado_valido AND tb1.exame_sifilis_realizado_valido IS FALSE THEN 1 -- Apenas Ex. de HIV realizados
+                    WHEN tb1.exame_sifilis_realizado_valido AND tb1.exame_hiv_realizado_valido IS FALSE THEN 2 -- Apenas Ex. de Sífilis realizados
+                    WHEN tb1.exame_sifilis_realizado_valido IS FALSE AND tb1.exame_hiv_realizado_valido IS FALSE THEN 3 -- Nenhum exame realizado
+                    WHEN tb1.exame_sifilis_realizado_valido AND tb1.exame_hiv_realizado_valido THEN 4 -- Os dois exames realizados
                     ELSE NULL::integer
                 END AS id_exame_hiv_sifilis,
                 CASE
                     WHEN tb1.possui_registro_aborto = 'Sim'::text THEN 10 -- Gestantes com registro de aborto
+                    WHEN tb1.gestacao_data_dpp IS NULL
+                        OR tb1.gestacao_data_dpp < (CASE -- Ou DPP é menor que a data de início do quadrimestre anterior
+                            WHEN date_part('month', CURRENT_DATE) >= 1 AND date_part('month', CURRENT_DATE) <= 4 THEN concat((date_part('year', CURRENT_DATE) - 1), '-09-01')::DATE
+                            WHEN date_part('month', CURRENT_DATE) >= 5 AND date_part('month', CURRENT_DATE) <= 8 THEN concat(date_part('year', CURRENT_DATE), '-01-01')::DATE
+                            WHEN date_part('month', CURRENT_DATE) >= 9 AND date_part('month', CURRENT_DATE) <= 12 THEN concat(date_part('year', CURRENT_DATE), '-05-01')::DATE
+                         END) 
+                         THEN 11 -- Gestantes sem DUM 
                     WHEN tb1.gestacao_data_dpp > CURRENT_DATE THEN 8 -- Gestantes ativas
                     WHEN tb1.gestacao_data_dpp <= CURRENT_DATE THEN 9 -- Gestantes encerradas
-                    WHEN tb1.gestacao_data_dpp IS NULL THEN 11 -- Gestantes sem DUM 
                     ELSE NULL::integer
                 END AS id_status_usuario,
                 CASE

--- a/bd_analitico/esus-backups/impulso_previne_dados_nominais/views_materializadas/painel_gestantes_lista_nominal.sql
+++ b/bd_analitico/esus-backups/impulso_previne_dados_nominais/views_materializadas/painel_gestantes_lista_nominal.sql
@@ -61,7 +61,8 @@ AS WITH dados_anonimizados_demo_vicosa AS (
                     lista_nominal_gestantes.exame_sifilis_hiv_realizado_valido,
                     lista_nominal_gestantes.criacao_data
                    FROM impulso_previne_dados_nominais.lista_nominal_gestantes_unificada lista_nominal_gestantes
-                  WHERE lista_nominal_gestantes.municipio_id_sus::text = '317130'::text) res
+                  WHERE lista_nominal_gestantes.municipio_id_sus::text = '317130'::text
+                  and lista_nominal_gestantes.equipe_ine is not null) res
              JOIN configuracoes.nomes_ficticios_gestantes nomes ON res.seq = nomes.seq
              JOIN configuracoes.nomes_ficticios_diabeticos nomes2 ON res.seq = nomes2.seq
         ), dados_anonimizados_impulsolandia AS (
@@ -125,7 +126,8 @@ AS WITH dados_anonimizados_demo_vicosa AS (
                     lista_nominal_gestantes.exame_sifilis_hiv_realizado_valido,
                     lista_nominal_gestantes.criacao_data
                    FROM impulso_previne_dados_nominais.lista_nominal_gestantes_unificada lista_nominal_gestantes
-                  WHERE lista_nominal_gestantes.municipio_id_sus::text = '317130'::text) res
+                  WHERE lista_nominal_gestantes.municipio_id_sus::text = '317130'::text
+                  and lista_nominal_gestantes.equipe_ine is not null) res
              JOIN configuracoes.nomes_ficticios_gestantes nomes ON res.seq = nomes.seq
              JOIN configuracoes.nomes_ficticios_diabeticos nomes2 ON res.seq = nomes2.seq
         ), dados_transmissoes_recentes AS (

--- a/bd_analitico/esus-backups/impulso_previne_dados_nominais/views_materializadas/painel_gestantes_lista_nominal.sql
+++ b/bd_analitico/esus-backups/impulso_previne_dados_nominais/views_materializadas/painel_gestantes_lista_nominal.sql
@@ -61,8 +61,7 @@ AS WITH dados_anonimizados_demo_vicosa AS (
                     lista_nominal_gestantes.exame_sifilis_hiv_realizado_valido,
                     lista_nominal_gestantes.criacao_data
                    FROM impulso_previne_dados_nominais.lista_nominal_gestantes_unificada lista_nominal_gestantes
-                  WHERE lista_nominal_gestantes.municipio_id_sus::text = '317130'::text
-                  and lista_nominal_gestantes.equipe_ine is not null) res
+                  WHERE lista_nominal_gestantes.municipio_id_sus::text = '317130'::text) res
              JOIN configuracoes.nomes_ficticios_gestantes nomes ON res.seq = nomes.seq
              JOIN configuracoes.nomes_ficticios_diabeticos nomes2 ON res.seq = nomes2.seq
         ), dados_anonimizados_impulsolandia AS (
@@ -126,8 +125,7 @@ AS WITH dados_anonimizados_demo_vicosa AS (
                     lista_nominal_gestantes.exame_sifilis_hiv_realizado_valido,
                     lista_nominal_gestantes.criacao_data
                    FROM impulso_previne_dados_nominais.lista_nominal_gestantes_unificada lista_nominal_gestantes
-                  WHERE lista_nominal_gestantes.municipio_id_sus::text = '317130'::text
-                  and lista_nominal_gestantes.equipe_ine is not null) res
+                  WHERE lista_nominal_gestantes.municipio_id_sus::text = '317130'::text) res
              JOIN configuracoes.nomes_ficticios_gestantes nomes ON res.seq = nomes.seq
              JOIN configuracoes.nomes_ficticios_diabeticos nomes2 ON res.seq = nomes2.seq
         ), dados_transmissoes_recentes AS (

--- a/bd_analitico/principal/impulso_previne/views_materializadas/capitacao_ponderada_contagem_equipes.sql
+++ b/bd_analitico/principal/impulso_previne/views_materializadas/capitacao_ponderada_contagem_equipes.sql
@@ -58,8 +58,9 @@ AS SELECT res.periodo_codigo,
      LEFT JOIN listas_de_codigos.municipios m ON res.municipio_id_sus::bpchar = m.id_sus
   WHERE (res.periodo_codigo::text IN ( SELECT pe.periodo_codigo
            FROM dados_publicos.sisab_cadastros_municipios_equipe_todas pe
+           left join listas_de_codigos.periodos p on p.id = pe.periodo_id
           WHERE pe.periodo_codigo::text >= '2022.M5'::text
-          ORDER BY pe.periodo_codigo DESC
+          ORDER BY p.data_inicio  DESC
          LIMIT 1))
 WITH DATA;
 

--- a/bd_analitico/principal/impulso_previne/views_materializadas/caracterizacao_municipal_resumo.sql
+++ b/bd_analitico/principal/impulso_previne/views_materializadas/caracterizacao_municipal_resumo.sql
@@ -8,9 +8,10 @@ AS WITH rel_cadastros_equipes_todas AS (
             count(DISTINCT tb1_1.equipe_id_ine) AS equipe_total
            FROM dados_publicos.sisab_cadastros_municipios_equipe_todas tb1_1
           WHERE (tb1_1.periodo_codigo::text IN ( SELECT pe.periodo_codigo
-                   FROM dados_publicos.sisab_cadastros_municipios_equipe_todas pe
-                  WHERE pe.periodo_codigo::text >= '2022.M5'::text
-                  ORDER BY pe.periodo_codigo DESC
+           FROM dados_publicos.sisab_cadastros_municipios_equipe_todas pe
+             LEFT JOIN listas_de_codigos.periodos p ON p.id = pe.periodo_id
+          WHERE pe.periodo_codigo::text >= '2022.M5'::text
+          ORDER BY p.data_inicio DESC
                  LIMIT 1))
           GROUP BY tb1_1.municipio_id_sus, tb1_1.periodo_codigo
         ), rel_cadastros_equipes_validas AS (
@@ -19,10 +20,11 @@ AS WITH rel_cadastros_equipes_todas AS (
             sum(tb2_1.quantidade) FILTER (WHERE tb2_1.criterio_pontuacao = false) AS cadastros_equipes_validas,
             sum(tb2_1.quantidade) FILTER (WHERE tb2_1.criterio_pontuacao = true) AS cadastros_equipes_validas_com_ponderacao
            FROM dados_publicos.sisab_cadastros_municipios_equipe_validas tb2_1
-          WHERE (tb2_1.periodo_codigo::text IN ( SELECT pe.periodo_codigo
-                   FROM dados_publicos.sisab_cadastros_municipios_equipe_validas pe
-                  WHERE pe.periodo_codigo::text >= '2022.M5'::text
-                  ORDER BY pe.periodo_codigo DESC
+          WHERE (tb2_1.periodo_codigo::text IN (SELECT pe.periodo_codigo
+           FROM dados_publicos.sisab_cadastros_municipios_equipe_todas pe
+             LEFT JOIN listas_de_codigos.periodos p ON p.id = pe.periodo_id
+          WHERE pe.periodo_codigo::text >= '2022.M5'::text
+          ORDER BY p.data_inicio DESC
                  LIMIT 1))
           GROUP BY tb2_1.municipio_id_sus, tb2_1.periodo_codigo
         ), rel_parametro_equipes_validas AS (
@@ -31,9 +33,10 @@ AS WITH rel_cadastros_equipes_todas AS (
             tb3_1.parametro
            FROM dados_publicos.sisab_cadastros_parametro_municipios_equipes_validas tb3_1
           WHERE (tb3_1.periodo_codigo::text IN ( SELECT pe.periodo_codigo
-                   FROM dados_publicos.sisab_cadastros_parametro_municipios_equipes_validas pe
-                  WHERE pe.periodo_codigo::text >= '2022.M5'::text
-                  ORDER BY pe.periodo_codigo DESC
+           FROM dados_publicos.sisab_cadastros_municipios_equipe_todas pe
+             LEFT JOIN listas_de_codigos.periodos p ON p.id = pe.periodo_id
+          WHERE pe.periodo_codigo::text >= '2022.M5'::text
+          ORDER BY p.data_inicio DESC
                  LIMIT 1))
         )
  SELECT tb1.periodo_codigo,
@@ -53,6 +56,7 @@ AS WITH rel_cadastros_equipes_todas AS (
      LEFT JOIN rel_cadastros_equipes_validas tb2 ON tb4.id_sus = tb2.municipio_id_sus::bpchar
      LEFT JOIN rel_parametro_equipes_validas tb3 ON tb4.id_sus = tb3.municipio_id_sus::bpchar
 WITH DATA;
+
 
 -- View indexes:
 CREATE INDEX caracterizacao_municipal_resumo_municipio_uf_idx ON impulso_previne.caracterizacao_municipal_resumo USING btree (municipio_uf);

--- a/docs/pull_request_template.md
+++ b/docs/pull_request_template.md
@@ -23,8 +23,12 @@ Exemplo de validações quantitativas
 
 Próximos passos: 
 <<<<<<< HEAD
+<<<<<<< HEAD
 - [] Comunicar ajustes importantes nos canais próprios de cada lista nominal
 =======
 - [] Comunicar ajustes importantes no canais próprios de cada lista nominal
 >>>>>>> 47386ab (Update pull_request_template.md)
+=======
+- [] Comunicar ajustes importantes nos canais próprios de cada lista nominal
+>>>>>>> 902530b (Update pull_request_template.md)
 - [] Atualizar documentação de regras de negócio no [Notion](https://www.notion.so/impulsogov/Documenta-o-Listas-Nominais-8e919b380bc04783a02f2a74df9e81ce)  

--- a/docs/pull_request_template.md
+++ b/docs/pull_request_template.md
@@ -22,5 +22,9 @@ Exemplo de validações quantitativas
 [Análises quantitativas nessa planilha](https://docs.google.com/spreadsheets/d/16wIQONmHASLjEbpVE6aR3B9X3S6LHJ06kY1xXUU3kbY/edit#gid=788815878)
 
 Próximos passos: 
+<<<<<<< HEAD
 - [] Comunicar ajustes importantes nos canais próprios de cada lista nominal
+=======
+- [] Comunicar ajustes importantes no canais próprios de cada lista nominal
+>>>>>>> 47386ab (Update pull_request_template.md)
 - [] Atualizar documentação de regras de negócio no [Notion](https://www.notion.so/impulsogov/Documenta-o-Listas-Nominais-8e919b380bc04783a02f2a74df9e81ce)  


### PR DESCRIPTION
_**Alterações de código das listas nominais**_

**Motivo do ajuste:**
O filtro aplicado ao final da view impulso_previne.capitacao_ponderada_contagem_equipes não estava trazendo os dados da competência disponível no banco mais recente.

**O que está sendo alterado:**
Filtro ao final do código, substituindo o parâmetro periodo_codigo por periodo_data_inicio na ordenação.


_**Validações obrigatórias**_


(Se modelagem no banco de dados)
- [x] Código ajustado funcionando no bd analítico



Alteração simples sem necessidade de validações mais aprofundadas
