### PR TITLE
Corrige cálculo da data de produção mais recente no painel de vacinação

### DIFF
--- a/bd_analitico/esus-backups/impulso_previne_dados_nominais/views_materializadas/painel_vacinacao_lista_nominal.sql
+++ b/bd_analitico/esus-backups/impulso_previne_dados_nominais/views_materializadas/painel_vacinacao_lista_nominal.sql
@@ -415,10 +415,28 @@ AS WITH dados_anonimizados_demo_vicosa AS (
         ), data_registro_producao AS (
          SELECT une_as_bases.municipio_id_sus,
             impulso_previne_dados_nominais.equipe_ine(une_as_bases.municipio_id_sus::text, COALESCE(une_as_bases.equipe_ine_cadastro, une_as_bases.equipe_ine_atendimento)::text) AS equipe_ine,
-            max(GREATEST(une_as_bases.data_1dose_polio, une_as_bases.data_2dose_polio, une_as_bases.data_3dose_polio, une_as_bases.data_1dose_penta, une_as_bases.data_2dose_penta, une_as_bases.data_3dose_penta)) AS dt_registro_producao_mais_recente,
-            min(LEAST(une_as_bases.data_1dose_polio, une_as_bases.data_2dose_polio, une_as_bases.data_3dose_polio, une_as_bases.data_1dose_penta, une_as_bases.data_2dose_penta, une_as_bases.data_3dose_penta)) AS dt_registro_producao_mais_antigo
+            max(GREATEST(une_as_bases.data_1dose_polio, 
+			            une_as_bases.data_2dose_polio, 
+			            une_as_bases.data_3dose_polio, 
+			            une_as_bases.data_1dose_penta, 
+			            une_as_bases.data_2dose_penta, 
+			            une_as_bases.data_3dose_penta, 
+			            une_as_bases.data_ultimo_cadastro_individual,
+			            une_as_bases.data_ultimo_atendimento_individual,
+			            une_as_bases.data_ultima_vista_domiciliar
+			            )) AS dt_registro_producao_mais_recente,
+            min(LEAST(une_as_bases.data_1dose_polio, 
+			            une_as_bases.data_2dose_polio, 
+			            une_as_bases.data_3dose_polio, 
+			            une_as_bases.data_1dose_penta, 
+			            une_as_bases.data_2dose_penta, 
+			            une_as_bases.data_3dose_penta, 
+			            une_as_bases.data_ultimo_cadastro_individual,
+			            une_as_bases.data_ultimo_atendimento_individual,
+			            une_as_bases.data_ultima_vista_domiciliar
+			            )) AS dt_registro_producao_mais_antigo
            FROM une_as_bases
-          GROUP BY une_as_bases.municipio_id_sus, (impulso_previne_dados_nominais.equipe_ine(une_as_bases.municipio_id_sus::text, COALESCE(une_as_bases.equipe_ine_cadastro, une_as_bases.equipe_ine_atendimento)::text))
+          GROUP BY 1,2
         ), tabela_aux AS (
          SELECT tb1.municipio_id_sus,
             tb1.cidadao_nome,
@@ -472,9 +490,9 @@ AS WITH dados_anonimizados_demo_vicosa AS (
                     WHEN tb1.data_1dose_penta IS NULL AND tb1.data_2dose_penta IS NULL AND tb1.data_3dose_penta IS NULL AND tb1.prazo_1dose_penta >= CURRENT_DATE AND tb1.prazo_2dose_penta >= CURRENT_DATE AND tb1.prazo_3dose_penta >= CURRENT_DATE THEN 4
                     ELSE NULL::integer
                 END AS id_status_penta,
-            COALESCE(tb1.acs_nome_visita, tb1.acs_nome_cadastro, 'SEM VISITA OU CADASTRO'::text) AS acs_nome,
+            COALESCE(tb1.acs_nome_visita, tb1.acs_nome_cadastro, '(SEM VISITA OU CADASTRO)'::text) AS acs_nome,
             impulso_previne_dados_nominais.equipe_ine(tb1.municipio_id_sus::text, COALESCE(tb1.equipe_ine_cadastro, tb1.equipe_ine_atendimento)::text) AS equipe_ine,
-            COALESCE(tb1.equipe_nome_cadastro, tb1.equipe_nome_atendimento, 'SEM EQUIPE'::character varying) AS equipe_nome,
+            COALESCE(tb1.equipe_nome_cadastro, tb1.equipe_nome_atendimento, '(SEM EQUIPE)'::character varying) AS equipe_nome,
             CURRENT_DATE AS atualizacao_data,
             tb1.criacao_data::date AS criacao_data
            FROM une_as_bases tb1


### PR DESCRIPTION
_**Alterações de código das listas nominais**_

**Motivo do ajuste:**
Foi relatado pelo município de Campos Novos - SC que a data de produção mais recente recebida na lista de vacinação estava divergente. Ao analisar o código do `painel_vacinacao_lista_nominal`, na CTE `data_registro_producao`, realmente faltou incluir alguns parâmetros ao calcular a data de produção mais recente recebida (estávamos olhando somente as datas de registro da vacina).

**O que está sendo alterado:**
Na CTE que calcula a data do registro de produção mais recente, estão sendo adicionados os campos de data do atendimento mais recente, data do último cadastro e data da última visita domiciliar.

_**Validações obrigatórias**_


(Se modelagem no banco de dados)
- [x] Código ajustado funcionando no bd analítico

[Códigos sql para validações quantitativas - Scripts/validacoes_listas_nominais](https://github.com/ImpulsoGov/bd/tree/b3e45be01efc4e82ce4985ed4df9af6d0f286a41/Scripts/validacoes_listas_nominais))
- [x] Check duplicados e variação de linhas : Não houve variação entre antes e depois da alteração.
- [] Check variações denominador e numerador do quadrimestre atual por município (não realizado devido à alteração ser muito simples)

Exemplo de validações quantitativas
[Análises quantitativas nessa planilha](https://docs.google.com/spreadsheets/d/1LNGuJ3bxwCy2J5EFMNj5vSHQvClN2qilS_NKHKeCaDQ/edit#gid=0)

Próximos passos: 
- [] Comunicar ajustes importantes nos canais próprios de cada lista nominal
- [] Atualizar documentação de regras de negócio no [Notion](https://www.notion.so/impulsogov/Documenta-o-Listas-Nominais-8e919b380bc04783a02f2a74df9e81ce)  
