### PR TITLE
Ajustes regras de vinculação - painel de gestantes

### DIFF
--- a/bd_analitico/esus-backups/impulso_previne_dados_nominais/views_materializadas/lista_nominal_gestantes_unificada.sql
+++ b/bd_analitico/esus-backups/impulso_previne_dados_nominais/views_materializadas/lista_nominal_gestantes_unificada.sql
@@ -178,7 +178,7 @@ AS WITH base_atendimentos_pre_natal AS (
                 apn.criacao_data
            FROM base_atendimentos_pre_natal apn
              JOIN analise_gestante cg ON cg.chave_gestante::text = apn.chave_gestante::text AND cg.municipio_id_sus::text = apn.municipio_id_sus::text
-          WHERE apn.data_atendimento < cg.data_fim_primeira_gestacao OR cg.data_fim_primeira_gestacao IS NULL
+          WHERE apn.data_atendimento <= cg.data_fim_primeira_gestacao OR cg.data_fim_primeira_gestacao IS NULL
         UNION ALL
          SELECT apn.municipio_id_sus,
             apn.chave_gestante::text || '_2'::text AS chave_gestacao,
@@ -214,10 +214,10 @@ AS WITH base_atendimentos_pre_natal AS (
                 apn.criacao_data
            FROM base_atendimentos_pre_natal apn
              JOIN analise_gestante cg ON cg.chave_gestante::text = apn.chave_gestante::text AND cg.municipio_id_sus::text = apn.municipio_id_sus::text
-          WHERE apn.data_atendimento >= cg.data_fim_primeira_gestacao
+          WHERE apn.data_atendimento > cg.data_fim_primeira_gestacao
         ), infos_gestante_atendimento_individual_recente AS (
-         WITH base AS (
-                 SELECT b.municipio_id_sus,
+                SELECT  
+                    b.municipio_id_sus,
                     b.chave_gestante,
                     b.gestante_nome,
                     b.gestante_data_de_nascimento,
@@ -228,6 +228,7 @@ AS WITH base_atendimentos_pre_natal AS (
                     b.estabelecimento_nome_atendimento,
                     b.equipe_ine_atendimento,
                     b.equipe_nome_atendimento,
+                    b.profissional_nome_atendimento,
                     b.data_ultimo_cadastro_individual,
                     b.estabelecimento_cnes_cad_indivual,
                     b.estabelecimento_nome_cad_individual,
@@ -237,33 +238,9 @@ AS WITH base_atendimentos_pre_natal AS (
                     b.data_ultima_visita_acs,
                     b.acs_visita_domiciliar,
                     b.acs_cad_dom_familia,
-                    row_number() OVER (PARTITION BY b.chave_gestante ORDER BY b.id_registro DESC) = 1 AS ultimo_atendimento_individual
-                   FROM impulso_previne_dados_nominais.eventos_pre_natal b
-                  WHERE b.tipo_registro::text = 'consulta_pre_natal'::text
-                )
-         SELECT base.municipio_id_sus,
-            base.chave_gestante,
-            base.gestante_nome,
-            base.gestante_data_de_nascimento,
-            base.gestante_documento_cpf,
-            base.gestante_documento_cns,
-            base.gestante_telefone,
-            base.estabelecimento_cnes_atendimento,
-            base.estabelecimento_nome_atendimento,
-            base.equipe_ine_atendimento,
-            base.equipe_nome_atendimento,
-            base.data_ultimo_cadastro_individual,
-            base.estabelecimento_cnes_cad_indivual,
-            base.estabelecimento_nome_cad_individual,
-            base.equipe_ine_cad_individual,
-            base.equipe_nome_cad_individual,
-            base.acs_cad_individual,
-            base.data_ultima_visita_acs,
-            base.acs_visita_domiciliar,
-            base.acs_cad_dom_familia,
-            base.ultimo_atendimento_individual
-           FROM base
-          WHERE base.ultimo_atendimento_individual IS TRUE
+                    row_number() OVER (PARTITION BY b.chave_gestante, b.municipio_id_sus ORDER BY b.id_registro DESC) = 1 AS ultimo_atendimento_individual
+                FROM impulso_previne_dados_nominais.eventos_pre_natal b
+                WHERE b.tipo_registro::text = 'consulta_pre_natal'::text
         ), base_final_gestacoes AS (
          SELECT bag.municipio_id_sus,
             bag.chave_gestacao,
@@ -272,11 +249,17 @@ AS WITH base_atendimentos_pre_natal AS (
             ig.gestante_telefone,
             ig.gestante_nome,
             ig.gestante_data_de_nascimento,
-            COALESCE(NULLIF(ig.estabelecimento_cnes_cad_indivual::text, '-'::text), ig.estabelecimento_cnes_atendimento::text) AS estabelecimento_cnes,
-            upper(COALESCE(NULLIF(ig.estabelecimento_nome_cad_individual::text, 'Não informado'::text), ig.estabelecimento_nome_atendimento::text)) AS estabelecimento_nome,
-            COALESCE(NULLIF(ig.equipe_ine_cad_individual::text, '-'::text), ig.equipe_ine_atendimento::text) AS equipe_ine,
-            upper(COALESCE(NULLIF(ig.equipe_nome_cad_individual::text, 'SEM EQUIPE'::text), ig.equipe_nome_atendimento::text)) AS equipe_nome,
-            upper(COALESCE(ig.acs_visita_domiciliar, ig.acs_cad_individual, 'SEM ACS'::character varying)::text) AS acs_nome,
+            ig.estabelecimento_cnes_cad_indivual,
+            ig.estabelecimento_cnes_atendimento,
+            ig.estabelecimento_nome_cad_individual,
+            ig.estabelecimento_nome_atendimento,
+            ig.equipe_ine_cad_individual,
+            ig.equipe_ine_atendimento,
+            ig.equipe_nome_cad_individual,
+            ig.equipe_nome_atendimento,
+            ig.acs_visita_domiciliar,
+            ig.acs_cad_individual,
+            ig.profissional_nome_atendimento,
             ig.data_ultima_visita_acs AS acs_data_ultima_visita,
             bag.data_primeira_dum_valida AS gestacao_data_dum,
             (bag.data_primeira_dum_valida + '294 days'::interval)::date AS gestacao_data_dpp,
@@ -399,42 +382,52 @@ AS WITH base_atendimentos_pre_natal AS (
                     ELSE 'Não'::text
                 END AS possui_registro_parto,
                 max(bag.criacao_data) as criacao_data
-           FROM base_atendimentos_por_gestacao bag
-             LEFT JOIN infos_gestante_atendimento_individual_recente ig ON bag.chave_gestante::text = ig.chave_gestante::text AND bag.municipio_id_sus::text = ig.municipio_id_sus::text
-             LEFT JOIN impulso_previne_dados_nominais.eventos_pre_natal odonto ON bag.chave_gestante::text = odonto.chave_gestante::text AND bag.municipio_id_sus::text = odonto.municipio_id_sus::text AND odonto.tipo_registro::text = 'atendimento_odontologico'::text
-             LEFT JOIN impulso_previne_dados_nominais.eventos_pre_natal sifilis ON bag.chave_gestante::text = sifilis.chave_gestante::text AND bag.municipio_id_sus::text = sifilis.municipio_id_sus::text AND (sifilis.tipo_registro::text = ANY (ARRAY['teste_rapido_exame_sifilis'::character varying, 'exame_sifilis_avaliado'::character varying]::text[]))
-             LEFT JOIN impulso_previne_dados_nominais.eventos_pre_natal hiv ON bag.chave_gestante::text = hiv.chave_gestante::text AND bag.municipio_id_sus::text = hiv.municipio_id_sus::text AND (hiv.tipo_registro::text = ANY (ARRAY['teste_rapido_exame_hiv'::character varying, 'exame_hiv_avaliado'::character varying]::text[]))
-             LEFT JOIN impulso_previne_dados_nominais.eventos_pre_natal parto ON bag.chave_gestante::text = parto.chave_gestante::text AND bag.municipio_id_sus::text = parto.municipio_id_sus::text AND parto.tipo_registro::text = 'registro_de_parto'::text
-             LEFT JOIN impulso_previne_dados_nominais.eventos_pre_natal aborto ON bag.chave_gestante::text = aborto.chave_gestante::text AND bag.municipio_id_sus::text = aborto.municipio_id_sus::text AND aborto.tipo_registro::text = 'registro_de_aborto'::text
-          GROUP BY bag.municipio_id_sus, bag.chave_gestacao, bag.ordem_gestacao, bag.chave_gestante, ig.gestante_telefone, ig.gestante_nome, ig.gestante_data_de_nascimento, (COALESCE(NULLIF(ig.estabelecimento_cnes_cad_indivual::text, '-'::text), ig.estabelecimento_cnes_atendimento::text)), (upper(COALESCE(NULLIF(ig.estabelecimento_nome_cad_individual::text, 'Não informado'::text), ig.estabelecimento_nome_atendimento::text))), (COALESCE(NULLIF(ig.equipe_ine_cad_individual::text, '-'::text), ig.equipe_ine_atendimento::text)), (upper(COALESCE(NULLIF(ig.equipe_nome_cad_individual::text, 'SEM EQUIPE'::text), ig.equipe_nome_atendimento::text))), (upper(COALESCE(ig.acs_visita_domiciliar, ig.acs_cad_individual, 'SEM ACS'::character varying)::text)), ig.data_ultima_visita_acs, bag.data_primeira_dum_valida, ((bag.data_primeira_dum_valida + '294 days'::interval)::date), ((bag.data_primeira_dum_valida + '294 days'::interval)::date - CURRENT_DATE), (
-                CASE
-                    WHEN (bag.data_primeira_dum_valida + '294 days'::interval)::date >= '2022-01-01'::date AND (bag.data_primeira_dum_valida + '294 days'::interval)::date <= '2022-04-30'::date THEN '2022.Q1'::text
-                    WHEN (bag.data_primeira_dum_valida + '294 days'::interval)::date >= '2022-05-01'::date AND (bag.data_primeira_dum_valida + '294 days'::interval)::date <= '2022-08-31'::date THEN '2022.Q2'::text
-                    WHEN (bag.data_primeira_dum_valida + '294 days'::interval)::date >= '2022-09-01'::date AND (bag.data_primeira_dum_valida + '294 days'::interval)::date <= '2022-12-31'::date THEN '2022.Q3'::text
-                    WHEN (bag.data_primeira_dum_valida + '294 days'::interval)::date >= '2023-01-01'::date AND (bag.data_primeira_dum_valida + '294 days'::interval)::date <= '2023-04-30'::date THEN '2023.Q1'::text
-                    WHEN (bag.data_primeira_dum_valida + '294 days'::interval)::date >= '2023-05-01'::date AND (bag.data_primeira_dum_valida + '294 days'::interval)::date <= '2023-08-31'::date THEN '2023.Q2'::text
-                    WHEN (bag.data_primeira_dum_valida + '294 days'::interval)::date >= '2023-09-01'::date AND (bag.data_primeira_dum_valida + '294 days'::interval)::date <= '2023-12-31'::date THEN '2023.Q3'::text
-                    WHEN (bag.data_primeira_dum_valida + '294 days'::interval)::date >= '2024-01-01'::date AND (bag.data_primeira_dum_valida + '294 days'::interval)::date <= '2024-04-30'::date THEN '2024.Q1'::text
-                    WHEN (bag.data_primeira_dum_valida + '294 days'::interval)::date >= '2024-05-01'::date AND (bag.data_primeira_dum_valida + '294 days'::interval)::date <= '2024-08-31'::date THEN '2024.Q2'::text
-                    WHEN (bag.data_primeira_dum_valida + '294 days'::interval)::date >= '2024-09-01'::date AND (bag.data_primeira_dum_valida + '294 days'::interval)::date <= '2024-12-31'::date THEN '2024.Q3'::text
-                    WHEN (bag.data_primeira_dum_valida + '294 days'::interval)::date >= '2025-01-01'::date AND (bag.data_primeira_dum_valida + '294 days'::interval)::date <= '2025-04-30'::date THEN '2025.Q1'::text
-                    WHEN (bag.data_primeira_dum_valida + '294 days'::interval)::date >= '2025-05-01'::date AND (bag.data_primeira_dum_valida + '294 days'::interval)::date <= '2025-08-31'::date THEN '2025.Q2'::text
-                    WHEN (bag.data_primeira_dum_valida + '294 days'::interval)::date >= '2025-09-01'::date AND (bag.data_primeira_dum_valida + '294 days'::interval)::date <= '2025-08-31'::date THEN '2025.Q3'::text
-                    ELSE 'SEM QUADRI'::text
-                END), bag.idade_gestacional_atendimento_com_primeira_dum_valida, bag.data_primeiro_atendimento, bag.data_ultimo_atendimento, (CURRENT_DATE - bag.data_ultimo_atendimento), bag.data_fim_primeira_gestacao, bag.tipo_encerramento_primeira_gestacao, ig.gestante_documento_cpf, ig.gestante_documento_cns, bag.idade_gestacional_atual_com_primeira_dum_valida, bag.criacao_data
-        ), aux AS (
-         SELECT base_final_gestacoes.municipio_id_sus,
+            FROM base_atendimentos_por_gestacao bag
+            LEFT JOIN infos_gestante_atendimento_individual_recente ig 
+                ON bag.chave_gestante::text = ig.chave_gestante::text 
+                AND bag.municipio_id_sus::text = ig.municipio_id_sus::TEXT
+                AND ig.ultimo_atendimento_individual IS TRUE
+            LEFT JOIN impulso_previne_dados_nominais.eventos_pre_natal odonto 
+                ON bag.chave_gestante::text = odonto.chave_gestante::text 
+                AND bag.municipio_id_sus::text = odonto.municipio_id_sus::text 
+                AND odonto.tipo_registro::text = 'atendimento_odontologico'::text
+            LEFT JOIN impulso_previne_dados_nominais.eventos_pre_natal sifilis 
+                ON bag.chave_gestante::text = sifilis.chave_gestante::text 
+                AND bag.municipio_id_sus::text = sifilis.municipio_id_sus::text 
+                AND (sifilis.tipo_registro::text = ANY (ARRAY['teste_rapido_exame_sifilis'::character varying, 'exame_sifilis_avaliado'::character varying]::text[]))
+            LEFT JOIN impulso_previne_dados_nominais.eventos_pre_natal hiv 
+                ON bag.chave_gestante::text = hiv.chave_gestante::text 
+                AND bag.municipio_id_sus::text = hiv.municipio_id_sus::text 
+                AND (hiv.tipo_registro::text = ANY (ARRAY['teste_rapido_exame_hiv'::character varying, 'exame_hiv_avaliado'::character varying]::text[]))
+            LEFT JOIN impulso_previne_dados_nominais.eventos_pre_natal parto 
+                ON bag.chave_gestante::text = parto.chave_gestante::text 
+                AND bag.municipio_id_sus::text = parto.municipio_id_sus::text 
+                AND parto.tipo_registro::text = 'registro_de_parto'::text
+            LEFT JOIN impulso_previne_dados_nominais.eventos_pre_natal aborto 
+                ON bag.chave_gestante::text = aborto.chave_gestante::text 
+                AND bag.municipio_id_sus::text = aborto.municipio_id_sus::text 
+                AND aborto.tipo_registro::text = 'registro_de_aborto'::text
+            GROUP BY 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32
+        )
+        SELECT 
+            base_final_gestacoes.municipio_id_sus,
             base_final_gestacoes.chave_gestacao,
             base_final_gestacoes.ordem_gestacao,
             base_final_gestacoes.chave_gestante,
             base_final_gestacoes.gestante_telefone,
             base_final_gestacoes.gestante_nome,
             base_final_gestacoes.gestante_data_de_nascimento,
-            base_final_gestacoes.estabelecimento_cnes,
-            base_final_gestacoes.estabelecimento_nome,
-            base_final_gestacoes.equipe_ine,
-            base_final_gestacoes.equipe_nome,
-            base_final_gestacoes.acs_nome,
+            base_final_gestacoes.estabelecimento_cnes_cad_indivual,
+            base_final_gestacoes.estabelecimento_cnes_atendimento,
+            base_final_gestacoes.estabelecimento_nome_cad_individual,
+            base_final_gestacoes.estabelecimento_nome_atendimento,
+            base_final_gestacoes.equipe_ine_cad_individual,
+            base_final_gestacoes.equipe_ine_atendimento,
+            base_final_gestacoes.equipe_nome_cad_individual,
+            base_final_gestacoes.equipe_nome_atendimento,
+            base_final_gestacoes.acs_visita_domiciliar,
+            base_final_gestacoes.acs_cad_individual,
+            base_final_gestacoes.profissional_nome_atendimento,
             base_final_gestacoes.acs_data_ultima_visita,
             base_final_gestacoes.gestacao_data_dum,
             base_final_gestacoes.gestacao_data_dpp,
@@ -486,49 +479,4 @@ AS WITH base_atendimentos_pre_natal AS (
                     WHEN date_part('month'::text, CURRENT_DATE) >= 9::double precision AND date_part('month'::text, CURRENT_DATE) <= 12::double precision THEN concat(date_part('year'::text, CURRENT_DATE), '-05-01')
                     ELSE NULL::text
                 END::date
-        )
- SELECT aux.municipio_id_sus,
-    aux.chave_gestacao,
-    aux.ordem_gestacao,
-    aux.chave_gestante,
-    aux.gestante_telefone,
-    aux.gestante_nome,
-    aux.gestante_data_de_nascimento,
-    aux.estabelecimento_cnes,
-    aux.estabelecimento_nome,
-    aux.equipe_ine,
-    aux.equipe_nome,
-    aux.acs_nome,
-    aux.acs_data_ultima_visita,
-    aux.gestacao_data_dum,
-    aux.gestacao_data_dpp,
-    aux.gestacao_dpp_dias_para,
-    aux.gestacao_quadrimestre,
-    aux.gestacao_idade_gestacional_primeiro_atendimento,
-    aux.consulta_prenatal_primeira_data,
-    aux.consulta_prenatal_ultima_data,
-    aux.consulta_prenatal_ultima_dias_desde,
-    aux.data_fim_primeira_gestacao,
-    aux.tipo_encerramento_primeira_gestacao,
-    aux.gestante_documento_cpf,
-    aux.gestante_documento_cns,
-    aux.gestacao_idade_gestacional_atual,
-    aux.sinalizacao_erro_registro,
-    aux.gestacao_qtde_dums,
-    aux.ordem_primeira_consulta_com_dum,
-    aux.consultas_prenatal_total,
-    aux.consultas_pre_natal_validas,
-    aux.atendimento_odontologico_realizado,
-    aux.atendimento_odontologico_realizado_valido,
-    aux.exame_hiv_realizado,
-    aux.exame_hiv_realizado_valido,
-    aux.exame_sifilis_realizado,
-    aux.exame_sifilis_realizado_valido,
-    aux.possui_registro_aborto,
-    aux.possui_registro_parto,
-    aux.exame_sifilis_hiv_realizado,
-    aux.exame_sifilis_hiv_realizado_valido,
-    aux.atualizacao_data,
-    aux.criacao_data
-   FROM aux
 WITH DATA;

--- a/bd_analitico/esus-backups/impulso_previne_dados_nominais/views_materializadas/painel_gestantes_lista_nominal.sql
+++ b/bd_analitico/esus-backups/impulso_previne_dados_nominais/views_materializadas/painel_gestantes_lista_nominal.sql
@@ -1,140 +1,49 @@
 CREATE MATERIALIZED VIEW impulso_previne_dados_nominais.painel_gestantes_lista_nominal
 TABLESPACE pg_default
-AS WITH dados_anonimizados_demo_vicosa AS (
-         SELECT res.chave_gestacao,
-            res.estabelecimento_cnes,
-            res.estabelecimento_nome,
-            res.equipe_ine,
-            res.equipe_nome,
-            upper(nomes2.nome_ficticio) AS acs_nome,
-            res.acs_data_ultima_visita,
-            res.gestante_documento_cpf,
-            res.gestante_documento_cns,
-            upper(nomes.nome_ficticio) AS gestante_nome,
-            res.gestante_data_de_nascimento,
-            res.gestante_telefone,
-            res.gestacao_data_dum,
-            res.gestacao_idade_gestacional_atual,
-            res.gestacao_idade_gestacional_primeiro_atendimento,
-            res.gestacao_data_dpp,
-            res.gestacao_data_dpp AS gestacao_consulta_prenatal_data_limite,
-            res.gestacao_dpp_dias_para,
-            res.consultas_pre_natal_validas,
-            res.consulta_prenatal_ultima_data,
-            res.consulta_prenatal_ultima_dias_desde,
-            res.atendimento_odontologico_realizado_valido,
-            res.exame_hiv_realizado_valido,
-            res.exame_sifilis_realizado_valido,
-            res.exame_sifilis_hiv_realizado_valido,
-            res.possui_registro_aborto,
-            res.possui_registro_parto,
-            res.criacao_data,
-            '100111'::character varying AS municipio_id_sus
-           FROM ( SELECT row_number() OVER (PARTITION BY 0::integer) AS seq,
-                    lista_nominal_gestantes.chave_gestacao,
-                    lista_nominal_gestantes.gestante_telefone,
-                    lista_nominal_gestantes.gestante_nome,
-                    lista_nominal_gestantes.gestante_data_de_nascimento,
-                    lista_nominal_gestantes.estabelecimento_cnes,
-                    lista_nominal_gestantes.estabelecimento_nome,
-                    lista_nominal_gestantes.equipe_ine,
-                    lista_nominal_gestantes.equipe_nome,
-                    lista_nominal_gestantes.acs_nome,
-                    lista_nominal_gestantes.acs_data_ultima_visita,
-                    lista_nominal_gestantes.gestacao_data_dum,
-                    lista_nominal_gestantes.gestacao_data_dpp,
-                    lista_nominal_gestantes.gestacao_dpp_dias_para,
-                    lista_nominal_gestantes.gestacao_quadrimestre,
-                    lista_nominal_gestantes.gestacao_idade_gestacional_primeiro_atendimento,
-                    lista_nominal_gestantes.consulta_prenatal_primeira_data,
-                    lista_nominal_gestantes.consulta_prenatal_ultima_data,
-                    lista_nominal_gestantes.consulta_prenatal_ultima_dias_desde,
-                    concat(impulso_previne_dados_nominais.random_between(100000000, 999999999)::text, impulso_previne_dados_nominais.random_between(10, 99)::text) AS gestante_documento_cpf,
-                    concat('7', impulso_previne_dados_nominais.random_between(100000000, 999999999)::text, impulso_previne_dados_nominais.random_between(10000, 99999)::text) AS gestante_documento_cns,
-                    lista_nominal_gestantes.gestacao_idade_gestacional_atual,
-                    lista_nominal_gestantes.consultas_pre_natal_validas,
-                    lista_nominal_gestantes.atendimento_odontologico_realizado_valido,
-                    lista_nominal_gestantes.exame_hiv_realizado_valido,
-                    lista_nominal_gestantes.exame_sifilis_realizado_valido,
-                    lista_nominal_gestantes.possui_registro_aborto,
-                    lista_nominal_gestantes.possui_registro_parto,
-                    lista_nominal_gestantes.exame_sifilis_hiv_realizado_valido,
-                    lista_nominal_gestantes.criacao_data
-                   FROM impulso_previne_dados_nominais.lista_nominal_gestantes_unificada lista_nominal_gestantes
-                  WHERE lista_nominal_gestantes.municipio_id_sus::text = '317130'::text) res
-             JOIN configuracoes.nomes_ficticios_gestantes nomes ON res.seq = nomes.seq
-             JOIN configuracoes.nomes_ficticios_diabeticos nomes2 ON res.seq = nomes2.seq
-        ), dados_anonimizados_impulsolandia AS (
-         SELECT res.chave_gestacao,
-            res.estabelecimento_cnes,
-            res.estabelecimento_nome,
-            res.equipe_ine,
-            res.equipe_nome,
-            upper(nomes2.nome_ficticio) AS acs_nome,
-            res.acs_data_ultima_visita,
-            res.gestante_documento_cpf,
-            res.gestante_documento_cns,
-            upper(nomes.nome_ficticio) AS gestante_nome,
-            res.gestante_data_de_nascimento,
-            res.gestante_telefone,
-            res.gestacao_data_dum,
-            res.gestacao_idade_gestacional_atual,
-            res.gestacao_idade_gestacional_primeiro_atendimento,
-            res.gestacao_data_dpp,
-            res.gestacao_data_dpp AS gestacao_consulta_prenatal_data_limite,
-            res.gestacao_dpp_dias_para,
-            res.consultas_pre_natal_validas,
-            res.consulta_prenatal_ultima_data,
-            res.consulta_prenatal_ultima_dias_desde,
-            res.atendimento_odontologico_realizado_valido,
-            res.exame_hiv_realizado_valido,
-            res.exame_sifilis_realizado_valido,
-            res.exame_sifilis_hiv_realizado_valido,
-            res.possui_registro_aborto,
-            res.possui_registro_parto,
-            res.criacao_data,
-            '111111'::character varying AS municipio_id_sus
-           FROM ( SELECT row_number() OVER (PARTITION BY 0::integer) AS seq,
-                    lista_nominal_gestantes.chave_gestacao,
-                    lista_nominal_gestantes.gestante_telefone,
-                    lista_nominal_gestantes.gestante_nome,
-                    lista_nominal_gestantes.gestante_data_de_nascimento,
-                    lista_nominal_gestantes.estabelecimento_cnes,
-                    lista_nominal_gestantes.estabelecimento_nome,
-                    lista_nominal_gestantes.equipe_ine,
-                    lista_nominal_gestantes.equipe_nome,
-                    lista_nominal_gestantes.acs_nome,
-                    lista_nominal_gestantes.acs_data_ultima_visita,
-                    lista_nominal_gestantes.gestacao_data_dum,
-                    lista_nominal_gestantes.gestacao_data_dpp,
-                    lista_nominal_gestantes.gestacao_dpp_dias_para,
-                    lista_nominal_gestantes.gestacao_quadrimestre,
-                    lista_nominal_gestantes.gestacao_idade_gestacional_primeiro_atendimento,
-                    lista_nominal_gestantes.consulta_prenatal_primeira_data,
-                    lista_nominal_gestantes.consulta_prenatal_ultima_data,
-                    lista_nominal_gestantes.consulta_prenatal_ultima_dias_desde,
-                    concat(impulso_previne_dados_nominais.random_between(100000000, 999999999)::text, impulso_previne_dados_nominais.random_between(10, 99)::text) AS gestante_documento_cpf,
-                    concat('7', impulso_previne_dados_nominais.random_between(100000000, 999999999)::text, impulso_previne_dados_nominais.random_between(10000, 99999)::text) AS gestante_documento_cns,
-                    lista_nominal_gestantes.gestacao_idade_gestacional_atual,
-                    lista_nominal_gestantes.consultas_pre_natal_validas,
-                    lista_nominal_gestantes.atendimento_odontologico_realizado_valido,
-                    lista_nominal_gestantes.exame_hiv_realizado_valido,
-                    lista_nominal_gestantes.exame_sifilis_realizado_valido,
-                    lista_nominal_gestantes.possui_registro_aborto,
-                    lista_nominal_gestantes.possui_registro_parto,
-                    lista_nominal_gestantes.exame_sifilis_hiv_realizado_valido,
-                    lista_nominal_gestantes.criacao_data
-                   FROM impulso_previne_dados_nominais.lista_nominal_gestantes_unificada lista_nominal_gestantes
-                  WHERE lista_nominal_gestantes.municipio_id_sus::text = '317130'::text) res
-             JOIN configuracoes.nomes_ficticios_gestantes nomes ON res.seq = nomes.seq
-             JOIN configuracoes.nomes_ficticios_diabeticos nomes2 ON res.seq = nomes2.seq
-        ), dados_transmissoes_recentes AS (
-         SELECT tb1_1.chave_gestacao,
-            tb1_1.estabelecimento_cnes,
-            tb1_1.estabelecimento_nome,
-            tb1_1.equipe_ine,
-            tb1_1.equipe_nome,
-            tb1_1.acs_nome,
+AS WITH dados_transmissoes_recentes AS (
+        SELECT
+            tb1_1.chave_gestacao,
+            CASE 
+                WHEN TRIM(tb1_1.equipe_ine_atendimento) = '-' OR tb1_1.equipe_ine_atendimento = ' ' OR tb1_1.equipe_ine_atendimento IS NULL 
+                    THEN NULL
+                ELSE TRIM(tb1_1.equipe_ine_atendimento)
+            END AS equipe_ine_atendimento,
+            CASE 
+                WHEN TRIM(tb1_1.equipe_nome_cad_individual) = '-' OR tb1_1.equipe_nome_cad_individual = ' ' OR tb1_1.equipe_nome_cad_individual IS NULL 
+                    THEN NULL
+                ELSE TRIM(tb1_1.equipe_nome_cad_individual)
+            END AS equipe_ine_cadastro,
+            CASE 
+                WHEN tb1_1.equipe_nome_atendimento = ' ' OR tb1_1.equipe_nome_atendimento IS NULL OR tb1_1.equipe_nome_atendimento LIKE '%SEM EQUIPE%' 
+                    THEN NULL 
+                ELSE TRIM(tb1_1.equipe_nome_atendimento)
+            END AS equipe_nome_atendimento,
+            CASE 
+                WHEN tb1_1.equipe_nome_cad_individual = ' ' OR tb1_1.equipe_nome_cad_individual IS NULL OR tb1_1.equipe_nome_cad_individual LIKE '%SEM EQUIPE%' 
+                    THEN NULL 
+                ELSE TRIM(tb1_1.equipe_nome_cad_individual)
+            END AS equipe_nome_cadastro,
+            CASE 
+                WHEN UPPER(tb1_1.acs_cad_individual) LIKE '%PROFISSIONAL NÃO CADASTRADO%'
+                    THEN 'ERRO CADASTRO PROFISSIONAL'
+                WHEN tb1_1.acs_cad_individual = ' ' OR tb1_1.acs_cad_individual IS NULL OR UPPER(tb1_1.acs_cad_individual) LIKE '%NÃO INFORMADO%'
+                    THEN NULL 
+                ELSE TRIM(UPPER(tb1_1.acs_cad_individual))
+            END AS acs_nome_cadastro,
+            CASE 
+                WHEN UPPER(tb1_1.acs_visita_domiciliar) LIKE '%PROFISSIONAL NÃO CADASTRADO%'
+                    THEN 'ERRO CADASTRO PROFISSIONAL'
+                WHEN tb1_1.acs_visita_domiciliar = ' ' OR tb1_1.acs_visita_domiciliar IS NULL OR UPPER(tb1_1.acs_visita_domiciliar) LIKE '%NÃO INFORMADO%'
+                    THEN NULL 
+                ELSE TRIM(UPPER(tb1_1.acs_visita_domiciliar))
+            END AS acs_nome_visita,
+            CASE 
+                WHEN UPPER(tb1_1.profissional_nome_atendimento) LIKE '%PROFISSIONAL NÃO CADASTRADO%'
+                    THEN 'ERRO CADASTRO PROFISSIONAL'
+                WHEN tb1_1.profissional_nome_atendimento = ' ' OR tb1_1.profissional_nome_atendimento IS NULL OR UPPER(tb1_1.profissional_nome_atendimento) LIKE '%NÃO INFORMADO%'
+                    THEN NULL 
+                ELSE TRIM(UPPER(tb1_1.profissional_nome_atendimento))
+            END AS profissional_nome_atendimento,
             tb1_1.acs_data_ultima_visita,
             tb1_1.gestante_documento_cpf,
             tb1_1.gestante_documento_cns,
@@ -158,112 +67,21 @@ AS WITH dados_anonimizados_demo_vicosa AS (
             tb1_1.possui_registro_parto,
             tb1_1.criacao_data,
             tb1_1.municipio_id_sus
-           FROM impulso_previne_dados_nominais.lista_nominal_gestantes_unificada tb1_1
-        ), une_as_bases AS (
-         SELECT dados_anonimizados_demo_vicosa.chave_gestacao,
-            dados_anonimizados_demo_vicosa.estabelecimento_cnes,
-            dados_anonimizados_demo_vicosa.estabelecimento_nome,
-            dados_anonimizados_demo_vicosa.equipe_ine,
-            dados_anonimizados_demo_vicosa.equipe_nome,
-            dados_anonimizados_demo_vicosa.acs_nome,
-            dados_anonimizados_demo_vicosa.acs_data_ultima_visita,
-            dados_anonimizados_demo_vicosa.gestante_documento_cpf,
-            dados_anonimizados_demo_vicosa.gestante_documento_cns,
-            dados_anonimizados_demo_vicosa.gestante_nome,
-            dados_anonimizados_demo_vicosa.gestante_data_de_nascimento,
-            dados_anonimizados_demo_vicosa.gestante_telefone,
-            dados_anonimizados_demo_vicosa.gestacao_data_dum,
-            dados_anonimizados_demo_vicosa.gestacao_idade_gestacional_atual,
-            dados_anonimizados_demo_vicosa.gestacao_idade_gestacional_primeiro_atendimento,
-            dados_anonimizados_demo_vicosa.gestacao_data_dpp,
-            dados_anonimizados_demo_vicosa.gestacao_consulta_prenatal_data_limite,
-            dados_anonimizados_demo_vicosa.gestacao_dpp_dias_para,
-            dados_anonimizados_demo_vicosa.consultas_pre_natal_validas,
-            dados_anonimizados_demo_vicosa.consulta_prenatal_ultima_data,
-            dados_anonimizados_demo_vicosa.consulta_prenatal_ultima_dias_desde,
-            dados_anonimizados_demo_vicosa.atendimento_odontologico_realizado_valido,
-            dados_anonimizados_demo_vicosa.exame_hiv_realizado_valido,
-            dados_anonimizados_demo_vicosa.exame_sifilis_realizado_valido,
-            dados_anonimizados_demo_vicosa.exame_sifilis_hiv_realizado_valido,
-            dados_anonimizados_demo_vicosa.possui_registro_aborto,
-            dados_anonimizados_demo_vicosa.possui_registro_parto,
-            dados_anonimizados_demo_vicosa.criacao_data,
-            dados_anonimizados_demo_vicosa.municipio_id_sus
-           FROM dados_anonimizados_demo_vicosa
-        UNION ALL
-         SELECT dados_anonimizados_impulsolandia.chave_gestacao,
-            dados_anonimizados_impulsolandia.estabelecimento_cnes,
-            dados_anonimizados_impulsolandia.estabelecimento_nome,
-            dados_anonimizados_impulsolandia.equipe_ine,
-            dados_anonimizados_impulsolandia.equipe_nome,
-            dados_anonimizados_impulsolandia.acs_nome,
-            dados_anonimizados_impulsolandia.acs_data_ultima_visita,
-            dados_anonimizados_impulsolandia.gestante_documento_cpf,
-            dados_anonimizados_impulsolandia.gestante_documento_cns,
-            dados_anonimizados_impulsolandia.gestante_nome,
-            dados_anonimizados_impulsolandia.gestante_data_de_nascimento,
-            dados_anonimizados_impulsolandia.gestante_telefone,
-            dados_anonimizados_impulsolandia.gestacao_data_dum,
-            dados_anonimizados_impulsolandia.gestacao_idade_gestacional_atual,
-            dados_anonimizados_impulsolandia.gestacao_idade_gestacional_primeiro_atendimento,
-            dados_anonimizados_impulsolandia.gestacao_data_dpp,
-            dados_anonimizados_impulsolandia.gestacao_consulta_prenatal_data_limite,
-            dados_anonimizados_impulsolandia.gestacao_dpp_dias_para,
-            dados_anonimizados_impulsolandia.consultas_pre_natal_validas,
-            dados_anonimizados_impulsolandia.consulta_prenatal_ultima_data,
-            dados_anonimizados_impulsolandia.consulta_prenatal_ultima_dias_desde,
-            dados_anonimizados_impulsolandia.atendimento_odontologico_realizado_valido,
-            dados_anonimizados_impulsolandia.exame_hiv_realizado_valido,
-            dados_anonimizados_impulsolandia.exame_sifilis_realizado_valido,
-            dados_anonimizados_impulsolandia.exame_sifilis_hiv_realizado_valido,
-            dados_anonimizados_impulsolandia.possui_registro_aborto,
-            dados_anonimizados_impulsolandia.possui_registro_parto,
-            dados_anonimizados_impulsolandia.criacao_data,
-            dados_anonimizados_impulsolandia.municipio_id_sus
-           FROM dados_anonimizados_impulsolandia
-        UNION ALL
-         SELECT dados_transmissoes_recentes.chave_gestacao,
-            dados_transmissoes_recentes.estabelecimento_cnes,
-            dados_transmissoes_recentes.estabelecimento_nome,
-            dados_transmissoes_recentes.equipe_ine,
-            dados_transmissoes_recentes.equipe_nome,
-            dados_transmissoes_recentes.acs_nome,
-            dados_transmissoes_recentes.acs_data_ultima_visita,
-            dados_transmissoes_recentes.gestante_documento_cpf,
-            dados_transmissoes_recentes.gestante_documento_cns,
-            dados_transmissoes_recentes.gestante_nome,
-            dados_transmissoes_recentes.gestante_data_de_nascimento,
-            dados_transmissoes_recentes.gestante_telefone,
-            dados_transmissoes_recentes.gestacao_data_dum,
-            dados_transmissoes_recentes.gestacao_idade_gestacional_atual,
-            dados_transmissoes_recentes.gestacao_idade_gestacional_primeiro_atendimento,
-            dados_transmissoes_recentes.gestacao_data_dpp,
-            dados_transmissoes_recentes.gestacao_consulta_prenatal_data_limite,
-            dados_transmissoes_recentes.gestacao_dpp_dias_para,
-            dados_transmissoes_recentes.consultas_pre_natal_validas,
-            dados_transmissoes_recentes.consulta_prenatal_ultima_data,
-            dados_transmissoes_recentes.consulta_prenatal_ultima_dias_desde,
-            dados_transmissoes_recentes.atendimento_odontologico_realizado_valido,
-            dados_transmissoes_recentes.exame_hiv_realizado_valido,
-            dados_transmissoes_recentes.exame_sifilis_realizado_valido,
-            dados_transmissoes_recentes.exame_sifilis_hiv_realizado_valido,
-            dados_transmissoes_recentes.possui_registro_aborto,
-            dados_transmissoes_recentes.possui_registro_parto,
-            dados_transmissoes_recentes.criacao_data,
-            dados_transmissoes_recentes.municipio_id_sus
-           FROM dados_transmissoes_recentes
+        FROM impulso_previne_dados_nominais.lista_nominal_gestantes_unificada tb1_1
         ), data_registro_producao AS (
-         SELECT une_as_bases.municipio_id_sus,
-            impulso_previne_dados_nominais.equipe_ine(une_as_bases.municipio_id_sus::text, une_as_bases.equipe_ine) AS equipe_ine,
-            max(GREATEST(une_as_bases.consulta_prenatal_ultima_data)) AS dt_registro_producao_mais_recente,
-            min(LEAST(une_as_bases.consulta_prenatal_ultima_data)) AS dt_registro_producao_mais_antigo
-           FROM une_as_bases
-          GROUP BY une_as_bases.municipio_id_sus, (impulso_previne_dados_nominais.equipe_ine(une_as_bases.municipio_id_sus::text, une_as_bases.equipe_ine))
+            SELECT 
+                dtr.municipio_id_sus,
+                impulso_previne_dados_nominais.equipe_ine(dtr.municipio_id_sus::text, COALESCE(dtr.equipe_ine_cadastro, dtr.equipe_ine_atendimento, '0')) AS equipe_ine,
+                max(GREATEST(dtr.consulta_prenatal_ultima_data)) AS dt_registro_producao_mais_recente,
+                min(LEAST(dtr.consulta_prenatal_ultima_data)) AS dt_registro_producao_mais_antigo
+            FROM dados_transmissoes_recentes dtr
+            GROUP BY 1, 2
         ), tabela_aux AS (
-         SELECT tb1.chave_gestacao AS chave_id_gestacao,
+        SELECT 
+            tb1.chave_gestacao AS chave_id_gestacao,
             tb1.municipio_id_sus,
-            impulso_previne_dados_nominais.equipe_ine(tb1.municipio_id_sus::text, tb1.equipe_ine) AS equipe_ine,
-            impulso_previne_dados_nominais.equipe_ine(tb1.municipio_id_sus::text, tb1.equipe_nome) AS equipe_nome,
+            impulso_previne_dados_nominais.equipe_ine(tb1.municipio_id_sus::text, COALESCE(tb1.equipe_ine_cadastro, tb1.equipe_ine_atendimento, '0')) AS equipe_ine,
+            impulso_previne_dados_nominais.equipe_ine(tb1.municipio_id_sus::text, COALESCE(tb1.equipe_nome_cadastro, tb1.equipe_nome_atendimento, 'SEM EQUIPE RESPONSÁVEL')) AS equipe_nome,
             tb1.gestante_nome AS cidadao_nome,
             COALESCE(tb1.gestante_documento_cpf, tb1.gestante_data_de_nascimento::text) AS cidadao_cpf_dt_nascimento,
             tb1.gestacao_data_dpp,
@@ -353,37 +171,104 @@ AS WITH dados_anonimizados_demo_vicosa AS (
                     WHEN tb1.possui_registro_aborto = 'Não'::text THEN 2
                     ELSE 0
                 END AS id_registro_aborto,
-            tb1.acs_nome,
+            COALESCE(tb1.acs_nome_cadastro,tb1.acs_nome_visita, tb1.profissional_nome_atendimento, 'SEM PROFISSIONAL RESPONSÁVEL') AS acs_nome,
             CURRENT_DATE AS atualizacao_data,
             tb1.criacao_data::date AS criacao_data
-           FROM une_as_bases tb1
-          WHERE tb1.possui_registro_aborto = 'Não'::text
+        FROM dados_transmissoes_recentes tb1
+        WHERE tb1.possui_registro_aborto = 'Não'::text
         )
- SELECT tabela_aux.chave_id_gestacao,
-    tabela_aux.municipio_id_sus,
-    tabela_aux.equipe_ine,
-    tabela_aux.equipe_nome,
-    tabela_aux.cidadao_nome,
-    tabela_aux.cidadao_cpf_dt_nascimento,
-    tabela_aux.gestacao_data_dpp,
-    tabela_aux.gestacao_quadrimestre,
-    tabela_aux.gestacao_idade_gestacional_atual,
-    tabela_aux.gestacao_idade_gestacional_primeiro_atendimento,
-    tabela_aux.consulta_prenatal_ultima_data,
-    tabela_aux.consultas_pre_natal_validas,
-    tabela_aux.id_atendimento_odontologico,
-    tabela_aux.id_exame_hiv_sifilis,
-    tabela_aux.id_status_usuario,
-    tabela_aux.id_registro_parto,
-    tabela_aux.id_registro_aborto,
-    tabela_aux.acs_nome,
-    tabela_aux.atualizacao_data,
-    tabela_aux.criacao_data,
-    concat(tb2.nome, ' - ', tb2.uf_sigla) AS municipio_uf,
-    drp.dt_registro_producao_mais_recente
-   FROM tabela_aux
-     LEFT JOIN data_registro_producao drp ON drp.municipio_id_sus::text = tabela_aux.municipio_id_sus::text AND drp.equipe_ine = tabela_aux.equipe_ine
-     LEFT JOIN listas_de_codigos.municipios tb2 ON tabela_aux.municipio_id_sus::bpchar = tb2.id_sus
+    , tabela_final AS (
+        SELECT  
+            tabela_aux.*,
+            drp.dt_registro_producao_mais_recente,
+            concat(tb2.nome, ' - ', tb2.uf_sigla) AS municipio_uf,
+            ROW_NUMBER() OVER (PARTITION BY tabela_aux.municipio_id_sus) AS seq_demo_viscosa
+        FROM tabela_aux
+        LEFT JOIN data_registro_producao drp 
+            ON drp.municipio_id_sus::text = tabela_aux.municipio_id_sus::text 
+                AND drp.equipe_ine = tabela_aux.equipe_ine
+        LEFT JOIN listas_de_codigos.municipios tb2 
+            ON tabela_aux.municipio_id_sus::bpchar = tb2.id_sus
+    ), dados_demo_vicosa AS (
+        SELECT 
+            tf.chave_id_gestacao,
+            '111111' AS municipio_id_sus,
+            tf.equipe_ine,
+            tf.equipe_nome,
+            upper(nomes.nome_ficticio) AS cidadao_nome,
+            concat(impulso_previne_dados_nominais.random_between(100000000, 999999999)::text, impulso_previne_dados_nominais.random_between(10, 99)::text) AS cidadao_cpf_dt_nascimento,
+            tf.gestacao_data_dpp,
+            tf.gestacao_quadrimestre,
+            tf.gestacao_idade_gestacional_atual,
+            tf.gestacao_idade_gestacional_primeiro_atendimento,
+            tf.consulta_prenatal_ultima_data,
+            tf.consultas_pre_natal_validas,
+            tf.id_atendimento_odontologico,
+            tf.id_exame_hiv_sifilis,
+            tf.id_status_usuario,
+            tf.id_registro_parto,
+            tf.id_registro_aborto,
+            upper(nomes2.nome_ficticio) AS acs_nome,
+            tf.atualizacao_data,
+            tf.criacao_data,
+            tf.dt_registro_producao_mais_recente,
+            'Demo - Viçosa - MG' AS municipio_uf
+        FROM tabela_final tf
+        LEFT JOIN configuracoes.nomes_ficticios_citopatologico nomes 
+            ON tf.seq_demo_viscosa = nomes.seq
+        LEFT JOIN configuracoes.nomes_ficticios_hipertensos nomes2 
+            ON tf.seq_demo_viscosa = nomes2.seq
+        WHERE municipio_id_sus = '140015' -- BONFIM - RR
+    )
+    SELECT 
+        ddv.chave_id_gestacao,
+        ddv.municipio_id_sus,
+        ddv.equipe_ine,
+        ddv.equipe_nome,
+        ddv.cidadao_nome,
+        ddv.cidadao_cpf_dt_nascimento,
+        ddv.gestacao_data_dpp,
+        ddv.gestacao_quadrimestre,
+        ddv.gestacao_idade_gestacional_atual,
+        ddv.gestacao_idade_gestacional_primeiro_atendimento,
+        ddv.consulta_prenatal_ultima_data,
+        ddv.consultas_pre_natal_validas,
+        ddv.id_atendimento_odontologico,
+        ddv.id_exame_hiv_sifilis,
+        ddv.id_status_usuario,
+        ddv.id_registro_parto,
+        ddv.id_registro_aborto,
+        ddv.acs_nome,
+        ddv.atualizacao_data,
+        ddv.criacao_data,
+        ddv.dt_registro_producao_mais_recente,
+        ddv.municipio_uf
+    FROM dados_demo_vicosa ddv 
+UNION ALL 
+    SELECT 
+        tf.chave_id_gestacao,
+        tf.municipio_id_sus,
+        tf.equipe_ine,
+        tf.equipe_nome,
+        tf.cidadao_nome,
+        tf.cidadao_cpf_dt_nascimento,
+        tf.gestacao_data_dpp,
+        tf.gestacao_quadrimestre,
+        tf.gestacao_idade_gestacional_atual,
+        tf.gestacao_idade_gestacional_primeiro_atendimento,
+        tf.consulta_prenatal_ultima_data,
+        tf.consultas_pre_natal_validas,
+        tf.id_atendimento_odontologico,
+        tf.id_exame_hiv_sifilis,
+        tf.id_status_usuario,
+        tf.id_registro_parto,
+        tf.id_registro_aborto,
+        tf.acs_nome,
+        tf.atualizacao_data,
+        tf.criacao_data,
+        tf.dt_registro_producao_mais_recente,
+        tf.municipio_uf
+    FROM tabela_final tf
 WITH DATA;
 
 -- View indexes:

--- a/bd_analitico/esus-backups/impulso_previne_dados_nominais/views_materializadas/painel_gestantes_lista_nominal.sql
+++ b/bd_analitico/esus-backups/impulso_previne_dados_nominais/views_materializadas/painel_gestantes_lista_nominal.sql
@@ -189,7 +189,7 @@ AS WITH dados_transmissoes_recentes AS (
                 AND drp.equipe_ine = tabela_aux.equipe_ine
         LEFT JOIN listas_de_codigos.municipios tb2 
             ON tabela_aux.municipio_id_sus::bpchar = tb2.id_sus
-    ), dados_demo_vicosa AS (
+    ), dados_demo_bonfim AS (
         SELECT 
             tf.chave_id_gestacao,
             '111111' AS municipio_id_sus,
@@ -212,7 +212,7 @@ AS WITH dados_transmissoes_recentes AS (
             tf.atualizacao_data,
             tf.criacao_data,
             tf.dt_registro_producao_mais_recente,
-            'Demo - Viçosa - MG' AS municipio_uf
+            'Demo - Bonfim - RR' AS municipio_uf
         FROM tabela_final tf
         LEFT JOIN configuracoes.nomes_ficticios_citopatologico nomes 
             ON tf.seq_demo_viscosa = nomes.seq
@@ -243,7 +243,7 @@ AS WITH dados_transmissoes_recentes AS (
         ddv.criacao_data,
         ddv.dt_registro_producao_mais_recente,
         ddv.municipio_uf
-    FROM dados_demo_vicosa ddv 
+    FROM dados_demo_bonfim ddv 
 UNION ALL 
     SELECT 
         tf.chave_id_gestacao,


### PR DESCRIPTION
_**Alterações de código das listas nominais**_

**Motivo do ajuste:**
Revisões das regras de vinculação visando diminuir a % de cidadão sem equipe ou sem profissional

**O que está sendo alterado:**
view da lista unificada
- Retirada das regras de negócios
- ajuste na regra de definição da segunda gestação (bugs)

view do painel
- Tratamento de INE, nomes de equipe e nome de profissionais/ACS
- Remodelação dos dados da demo viçosa
- Revisão da regra de vinculação


_**Validações obrigatórias**_

(Se modelagem no banco de dados)
- [x] Código ajustado funcionando no bd analítico

- [x] Check duplicados e variação de linhas 
- [x] Check variações denominador e numerador do quadrimestre atual por município 

Exemplo de validações quantitativas
[Análises quantitativas nessa planilha](https://docs.google.com/spreadsheets/d/1OW9tWXXmn6g3D46URVpMJjqdPYKxKqPwDBpR4yYL5ZM/edit#gid=0)

Temos variações de linha devido a alteração da regra de negócio da janela de segunda gestação. 
109 gestações -> segunda gestações onde o registro de aborto ocorreu no mesmo dia da consulta de pré-natal - correção esperada
38 gestações -> mulher com atendimentos em mais de um município parceiro (backlog de ajustes)


Próximos passos: 
- [] Comunicar ajustes importantes nos canais próprios de cada lista nominal
- [] Comunicar ajustes importantes nos canais próprios de cada lista nominal
- [] Atualizar documentação de regras de negócio no [Notion](https://www.notion.so/impulsogov/Documenta-o-Listas-Nominais-8e919b380bc04783a02f2a74df9e81ce)  