### PR TITLE
Corrige cláusula que traz o ine do último cadastro e corrige ordenação da seleção final.

### DIFF
--- a/bd_analitico/esus-backups/impulso_previne_dados_nominais/views_materializadas/painel_gestantes_lista_nominal.sql
+++ b/bd_analitico/esus-backups/impulso_previne_dados_nominais/views_materializadas/painel_gestantes_lista_nominal.sql
@@ -8,10 +8,9 @@ AS WITH dados_transmissoes_recentes AS (
                     THEN NULL
                 ELSE TRIM(tb1_1.equipe_ine_atendimento)
             END AS equipe_ine_atendimento,
-            CASE 
-                WHEN TRIM(tb1_1.equipe_nome_cad_individual) = '-' OR tb1_1.equipe_nome_cad_individual = ' ' OR tb1_1.equipe_nome_cad_individual IS NULL 
-                    THEN NULL
-                ELSE TRIM(tb1_1.equipe_nome_cad_individual)
+            CASE
+                WHEN TRIM(tb1_1.equipe_ine_cad_individual::text) = '-'::text OR tb1_1.equipe_ine_cad_individual::text = ' '::text OR tb1_1.equipe_ine_cad_individual IS NULL THEN NULL::text
+                ELSE TRIM(tb1_1.equipe_ine_cad_individual::text)
             END AS equipe_ine_cadastro,
             CASE 
                 WHEN tb1_1.equipe_nome_atendimento = ' ' OR tb1_1.equipe_nome_atendimento IS NULL OR tb1_1.equipe_nome_atendimento LIKE '%SEM EQUIPE%' 
@@ -241,8 +240,8 @@ AS WITH dados_transmissoes_recentes AS (
         ddv.acs_nome,
         ddv.atualizacao_data,
         ddv.criacao_data,
-        ddv.dt_registro_producao_mais_recente,
-        ddv.municipio_uf
+        ddv.municipio_uf,
+        ddv.dt_registro_producao_mais_recente
     FROM dados_demo_bonfim ddv 
 UNION ALL 
     SELECT 
@@ -266,8 +265,8 @@ UNION ALL
         tf.acs_nome,
         tf.atualizacao_data,
         tf.criacao_data,
-        tf.dt_registro_producao_mais_recente,
-        tf.municipio_uf
+        tf.municipio_uf,
+        tf.dt_registro_producao_mais_recente
     FROM tabela_final tf
 WITH DATA;
 


### PR DESCRIPTION

_**Alterações de código das listas nominais**_

**Motivo do ajuste:**
Ao ativar a rotina de sincronização dos dados do painel de gestantes para o banco de produção, foi identificada uma falha ocasionada pelos seguintes motivos:
- O campo equipe_ine estava trazendo para alguns casos o nome da equipe. Gerando impossibilidade de inserir tais dados em um campo com o tipo varchar(20) devido à extensão dos nomes.
- A ordem dos campos da view estava diferente da ordem das colunas da tabela que recebe os dados da view.

**O que está sendo alterado:**
- A cláusula case que tráz o código ine do cadastro individual, foi corrigida para trazer o `equipe_ine_cad_individual `e não o `equipe_nome_cad_individual`
- Alteração da ordem dos dois últimos campos na seleção final (`municipio_uf` e `dt_registro_producao_mais_recente`)

_**Validações obrigatórias**_

(Se modelagem no banco de dados)
- [x] Código ajustado funcionando no bd analítico

[Códigos sql para validações quantitativas - Scripts/validacoes_listas_nominais](https://github.com/ImpulsoGov/bd/tree/b3e45be01efc4e82ce4985ed4df9af6d0f286a41/Scripts/validacoes_listas_nominais))
- [x] Check duplicados e variação de linhas 
Não houve variações entre os duplicados antes e depois da alteração.

Exemplo de validações quantitativas
[Análises quantitativas nessa planilha](https://docs.google.com/spreadsheets/d/1AdmtZjNrMW9WQhYBpb2QCKDpu0R-RAHkXVipQc35_NI/edit#gid=0)

Próximos passos: 
- [] Comunicar ajustes importantes nos canais próprios de cada lista nominal
- [] Comunicar ajustes importantes nos canais próprios de cada lista nominal
- [] Atualizar documentação de regras de negócio no [Notion](https://www.notion.so/impulsogov/Documenta-o-Listas-Nominais-8e919b380bc04783a02f2a74df9e81ce)  
