### PR TITLE
update: altera tipo de dado de 'co_fat_familia_territorio' para int8

### DIFF
--- a/transmissor_impulso_esus/ddls_tabelas_transmitidas/citopatologico.sql
+++ b/transmissor_impulso_esus/ddls_tabelas_transmitidas/citopatologico.sql
@@ -33,7 +33,7 @@ CREATE TABLE dados_ip_impulsolandia.lista_nominal_citopatologico (
 			equipe_nome_ultimo_atendimento varchar(500) NULL,
 			acs_nome_ultimo_atendimento varchar(500) NULL,
 			acs_nome_visita varchar(500) NULL,
-			co_fat_familia_territorio int4 NULL,
+			co_fat_familia_territorio int8 NULL,
 			cidadao_telefone varchar(30) NULL,
 			cidadao_celular varchar(30) NULL,
 			cidadao_situacao_trabalho varchar(500) NULL,

--- a/transmissor_impulso_esus/ddls_tabelas_transmitidas/diabeticos.sql
+++ b/transmissor_impulso_esus/ddls_tabelas_transmitidas/diabeticos.sql
@@ -35,7 +35,7 @@ CREATE TABLE dados_ip_impulsolandia.lista_nominal_diabeticos (
 	dt_ultima_consulta date NULL,
 	se_faleceu int4 NULL,
 	se_mudou int4 NULL,
-	co_fat_familia_territorio int4 NULL,
+	co_fat_familia_territorio int8 NULL,
 	cidadao_telefone varchar(30) NULL,
 	cidadao_celular varchar(30) NULL,
 	cidadao_situacao_trabalho varchar(500) NULL,

--- a/transmissor_impulso_esus/ddls_tabelas_transmitidas/hipertensos.sql
+++ b/transmissor_impulso_esus/ddls_tabelas_transmitidas/hipertensos.sql
@@ -35,7 +35,7 @@ CREATE TABLE dados_ip_impulsolandia.lista_nominal_hipertensos (
 	dt_ultima_consulta date NULL,
 	se_faleceu int4 NULL,
 	se_mudou int4 NULL,
-	co_fat_familia_territorio int4 NULL,
+	co_fat_familia_territorio int8 NULL,
 	cidadao_telefone varchar(30) NULL,
 	cidadao_celular varchar(30) NULL,
 	cidadao_situacao_trabalho varchar(500) NULL,


### PR DESCRIPTION
Descrição
Este PR altera o tipo de dado do campo `co_fat_familia_territorio` de int4 para int8, garantindo suporte a valores maiores

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Melhoramos o gerenciamento dos registros de saúde, ampliando a capacidade de armazenamento para valores numéricos maiores. Essa atualização aprimora a precisão e consistência das informações exibidas, garantindo que o sistema suporte eficientemente registros com uma faixa numérica mais ampla, resultando em uma experiência mais robusta para os usuários e maior confiabilidade nos dados.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->