### PR TITLE
Update: Altera nome do município da Demo de 'Bonfim - RR' para 'Monsenhor Tabosa - CE'

### DIFF
--- a/bd_analitico/esus-backups/impulso_previne_dados_nominais/views_materializadas/painel_citopatologico_lista_nominal.sql
+++ b/bd_analitico/esus-backups/impulso_previne_dados_nominais/views_materializadas/painel_citopatologico_lista_nominal.sql
@@ -163,7 +163,7 @@ AS WITH dados_transmissoes_recentes AS (
     ) , dados_demo_bonfim AS (
         SELECT 
             '111111' AS municipio_id_sus,
-            'Demo - Bonfim - RR' AS municipio_uf,
+            'Demo - Monsenhor Tabosa - CE' AS municipio_uf,
             upper(nomes.nome_ficticio) AS paciente_nome,
             concat(impulso_previne_dados_nominais.random_between(100000000, 999999999)::text, impulso_previne_dados_nominais.random_between(10, 99)::text) AS cidadao_cpf_dt_nascimento,
             tf.vencimento_da_coleta,

--- a/bd_analitico/esus-backups/impulso_previne_dados_nominais/views_materializadas/painel_enfermeiras_lista_nominal_diabeticos.sql
+++ b/bd_analitico/esus-backups/impulso_previne_dados_nominais/views_materializadas/painel_enfermeiras_lista_nominal_diabeticos.sql
@@ -251,7 +251,7 @@ AS WITH dados_transmissoes_recentes AS (
     ), dados_demo_bonfim AS (
             SELECT 
                 '111111' AS municipio_id_sus,
-                'Demo - Bonfim - RR' AS municipio_uf,
+                'Demo - Monsenhor Tabosa - CE' AS municipio_uf,
                 tf.quadrimestre_atual,
                 tf.realizou_solicitacao_hemoglobina_ultimos_6_meses,
                 tf.dt_solicitacao_hemoglobina_glicada_mais_recente,

--- a/bd_analitico/esus-backups/impulso_previne_dados_nominais/views_materializadas/painel_enfermeiras_lista_nominal_hipertensos.sql
+++ b/bd_analitico/esus-backups/impulso_previne_dados_nominais/views_materializadas/painel_enfermeiras_lista_nominal_hipertensos.sql
@@ -248,7 +248,7 @@ AS WITH dados_transmissoes_recentes AS (
     ), dados_demo_bonfim AS (
             SELECT 
                 '111111' AS municipio_id_sus,
-                'Demo - Bonfim - RR' AS municipio_uf,
+                'Demo - Monsenhor Tabosa - CE' AS municipio_uf,
                 tf.quadrimestre_atual,
                 tf.realizou_afericao_ultimos_6_meses,
                 tf.dt_afericao_pressao_mais_recente,

--- a/bd_analitico/esus-backups/impulso_previne_dados_nominais/views_materializadas/painel_gestantes_lista_nominal.sql
+++ b/bd_analitico/esus-backups/impulso_previne_dados_nominais/views_materializadas/painel_gestantes_lista_nominal.sql
@@ -211,7 +211,7 @@ AS WITH dados_transmissoes_recentes AS (
             tf.atualizacao_data,
             tf.criacao_data,
             tf.dt_registro_producao_mais_recente,
-            'Demo - Bonfim - RR' AS municipio_uf
+            'Demo - Monsenhor Tabosa - CE' AS municipio_uf
         FROM tabela_final tf
         LEFT JOIN configuracoes.nomes_ficticios_citopatologico nomes 
             ON tf.seq_demo_viscosa = nomes.seq

--- a/bd_analitico/esus-backups/impulso_previne_dados_nominais/views_materializadas/painel_vacinacao_lista_nominal.sql
+++ b/bd_analitico/esus-backups/impulso_previne_dados_nominais/views_materializadas/painel_vacinacao_lista_nominal.sql
@@ -304,7 +304,7 @@ AS WITH dados_transmissoes_recentes AS (
         ), dados_demo_bonfim AS (
             SELECT 
                 '111111' AS municipio_id_sus,
-                'Demo - Bonfim - RR' AS municipio_uf,
+                'Demo - Monsenhor Tabosa - CE' AS municipio_uf,
                 upper(nomes.nome_ficticio) AS cidadao_nome,
                 upper(nomes2.nome_ficticio) AS cidadao_nome_responsavel,
                 concat(impulso_previne_dados_nominais.random_between(100000000, 999999999)::text, impulso_previne_dados_nominais.random_between(10, 99)::text) AS cidadao_cpf_dt_nascimento,


### PR DESCRIPTION
**Descrição**
Este PR atualiza o nome do município de Demo, alterando 'Bonfim - RR' para 'Monsenhor Tabosa - CE' nos códigos dos paineis nominais. 
Por se tratar de um ajuste simples, que não impacta nas demais regras de negócio, não foram necessárias validações adicionais.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Atualizada a exibição dos dados de demonstração para que os painéis exibam o município correto, alterando de “Demo - Bonfim - RR” para “Demo - Monsenhor Tabosa - CE” em diversos relatórios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->